### PR TITLE
Fix/sync traQ user

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -499,7 +499,8 @@ paths:
     post:
       tags:
         - users
-      description: traQのuserと同期します。 
+      description: 管理者権限が必要。
+        traQのuserと同期します。 
         state=1については、ユーザーを作成。
         state=0については、存在している場合に限り、`token`を無効化します。(ユーザー削除はしません)
       responses:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -495,6 +495,17 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/userArray"
+  /users/sync:
+    post:
+      tags:
+        - users
+      description: traQのuserと同期します。 
+        state=1については、ユーザーを作成。
+        state=0については、存在している場合に限り、`token`を無効化します。(ユーザー削除はしません)
+      responses:
+        "201":
+          description: OK
+            
 
   /users/me:
     get:

--- a/repository/model.go
+++ b/repository/model.go
@@ -24,8 +24,9 @@ type StartEndTime struct {
 type UserMeta struct {
 	ID uuid.UUID `gorm:"type:char(36); primary_key"`
 	// Admin アプリの管理者かどうか
-	Admin bool   `gorm:"not null"`
-	Token string `gorm:"type:varbinary(64)"`
+	Admin      bool   `gorm:"not null"`
+	Istraq     bool   `gorm:"not null"`
+	Token      string `gorm:"type:varbinary(64)"`
 	IcalSecret string `gorm:"not null"`
 }
 

--- a/repository/model.go
+++ b/repository/model.go
@@ -25,7 +25,7 @@ type UserMeta struct {
 	ID uuid.UUID `gorm:"type:char(36); primary_key"`
 	// Admin アプリの管理者かどうか
 	Admin      bool   `gorm:"not null"`
-	Istraq     bool   `gorm:"not null"`
+	IsTraq     bool   `gorm:"not null"`
 	Token      string `gorm:"type:varbinary(64)"`
 	IcalSecret string `gorm:"not null"`
 }

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -138,7 +138,9 @@ func setupGormRepoWithUser(t *testing.T, repo string) (*GormRepository, *assert.
 
 func mustMakeUserMeta(t *testing.T, repo UserMetaRepository, admin bool) *UserMeta {
 	t.Helper()
-	user, err := repo.SaveUser(admin)
+	userID := mustNewUUIDV4(t)
+	// TODO fix consider not traQ user.
+	user, err := repo.SaveUser(userID, admin, true)
 	require.NoError(t, err)
 	return user
 }

--- a/repository/user.go
+++ b/repository/user.go
@@ -42,8 +42,9 @@ type UserBodyRepository interface {
 
 func (repo *GormRepository) SaveUser(userID uuid.UUID, isAdmin, istraQ bool) (*UserMeta, error) {
 	user := UserMeta{
-		ID:    userID,
-		Admin: isAdmin,
+		ID:     userID,
+		Admin:  isAdmin,
+		IsTraq: istraQ,
 	}
 	if err := repo.DB.Create(&user).Error; err != nil {
 		var me *mysql.MySQLError

--- a/repository/user_test.go
+++ b/repository/user_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	traQutils "github.com/traPtitech/traQ/utils"
 )
@@ -12,9 +13,25 @@ func TestGormRepository_SaveUser(t *testing.T) {
 	repo, _, _ := setupGormRepo(t, common)
 
 	t.Run("success", func(t *testing.T) {
-		t.Parallel()
-		_, err := repo.SaveUser(false)
+		userID := mustNewUUIDV4(t)
+		_, err := repo.SaveUser(userID, false, true)
 		assert.NoError(t, err)
+	})
+
+	t.Run("nil id", func(t *testing.T) {
+		userID := uuid.Nil
+		_, err := repo.SaveUser(userID, false, true)
+		// mysql Error number 1364
+		// Field 'id' doesn't have a default value
+		assert.Error(t, err)
+	})
+
+	t.Run("already exists", func(t *testing.T) {
+		userID := mustNewUUIDV4(t)
+		_, err := repo.SaveUser(userID, false, true)
+		assert.NoError(t, err)
+		_, err = repo.SaveUser(userID, false, true)
+		assert.EqualError(t, err, ErrAlreadyExists.Error())
 	})
 }
 

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -134,8 +134,8 @@ func (h *Handlers) WatchCallbackMiddleware() echo.MiddlewareFunc {
 			json.Unmarshal(bytes, userID)
 
 			// sess.Values["authorization"] = token
-			_, err = h.Repo.GetUser(userID.Value)
-			if err != nil {
+			_, err = h.Repo.SaveUser(userID.Value, false, true)
+			if err != nil && !errors.Is(err, repo.ErrAlreadyExists) {
 				return internalServerError(err)
 			}
 			if err := h.Dao.Repo.ReplaceToken(userID.Value, token); err != nil {

--- a/router/router.go
+++ b/router/router.go
@@ -114,6 +114,7 @@ func (h *Handlers) SetupRoute(db *gorm.DB) *echo.Echo {
 		apiUsers := api.Group("/users")
 		{
 			apiUsers.GET("", h.HandleGetUsers)
+			apiUsers.POST("/sync", h.HandleSyncUser, h.AdminUserMiddleware)
 
 			apiUsers.GET("/me", h.HandleGetUserMe)
 			apiUsers.GET("/me/ical", h.HandleGetiCal)

--- a/router/users.go
+++ b/router/users.go
@@ -1,10 +1,16 @@
 package router
 
 import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
 	"net/http"
+	"net/url"
+	"path"
 	"room/router/service"
 
 	"github.com/labstack/echo/v4"
+	traQv3 "github.com/traPtitech/traQ/router/v3"
 	traQutils "github.com/traPtitech/traQ/utils"
 )
 
@@ -65,4 +71,58 @@ func (h *Handlers) HandleUpdateiCal(c echo.Context) error {
 	}{
 		Secret: secret,
 	})
+}
+
+// HandleSyncUser traQのユーザーとの同期をする
+// 停止されているユーザーの`token`を削除して、
+// 活動中のユーザーを追加する(userIDをDBに保存)
+func (h *Handlers) HandleSyncUser(c echo.Context) error {
+	token, _ := getRequestUserToken(c)
+
+	// TODO fix with repository v4
+	allUsers, err := getTraQAllUsers(token)
+	if err != nil {
+		return internalServerError(err)
+	}
+	for _, user := range allUsers {
+		if user.State == 0 {
+			h.Repo.ReplaceToken(user.ID, "")
+		} else if user.State == 1 {
+			h.Repo.SaveUser(user.ID, false, true)
+		}
+	}
+	return c.NoContent(http.StatusOK)
+}
+
+func getTraQAllUsers(token string) ([]traQv3.User, error) {
+	u, err := url.Parse("https://q.trap.jp/api/v3")
+	if err != nil {
+		return nil, err
+	}
+	u.Path = path.Join(u.Path, "users")
+	query := u.Query()
+	query.Set("include-suspended", "1")
+	u.RawQuery = query.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode >= 400 {
+		return nil, errors.New(http.StatusText(res.StatusCode))
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	users := make([]traQv3.User, 0)
+	err = json.Unmarshal(data, &users)
+	return users, err
 }

--- a/router/users.go
+++ b/router/users.go
@@ -91,7 +91,7 @@ func (h *Handlers) HandleSyncUser(c echo.Context) error {
 			h.Repo.SaveUser(user.ID, false, true)
 		}
 	}
-	return c.NoContent(http.StatusOK)
+	return c.NoContent(http.StatusCreated)
 }
 
 func getTraQAllUsers(token string) ([]traQv3.User, error) {


### PR DESCRIPTION
`state=0`のユーザーのトークンを空文字列に変更（ユーザーが存在しない場合は何もしない）
`state=1`のユーザーを登録（ユーザーが既に存在する場合は何もしない）