### PR TITLE
Fix inlined oneOf schema in requestBodies

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -755,7 +755,10 @@ components:
         groupId: *uuid
         admins: *admins
         tags: *reqEventTags
-
+    RequestEventAll:
+      oneOf:
+        - $ref: "#/components/schemas/RequestEvent"
+        - $ref: "#/components/schemas/RequestEventInstant"
     duration:
       type: object
       properties:
@@ -810,9 +813,7 @@ components:
       content:
         application/json:
           schema:
-            oneOf:
-              - $ref: '#/components/schemas/RequestEvent'
-              - $ref: '#/components/schemas/RequestEventInstant'
+            $ref: '#/components/schemas/RequestEventAll'
             example:
               name: イベント
               description: これはイベントです。

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -742,7 +742,7 @@ components:
             properties:
               name: *tagName
               locked: *locked
-    RequestEvent:
+    RequestEventRoomStock:
       type: object
       description: 既存の部屋を使う
       properties:
@@ -755,10 +755,10 @@ components:
         groupId: *uuid
         admins: *admins
         tags: *reqEventTags
-    RequestEventAll:
+    RequestEvent:
       oneOf:
-        - $ref: "#/components/schemas/RequestEvent"
         - $ref: "#/components/schemas/RequestEventInstant"
+        - $ref: "#/components/schemas/RequestEventRoomStock"
     duration:
       type: object
       properties:
@@ -813,7 +813,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/RequestEventAll'
+            $ref: '#/components/schemas/RequestEvent'
             example:
               name: イベント
               description: これはイベントです。

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -742,7 +742,7 @@ components:
             properties:
               name: *tagName
               locked: *locked
-    RequestEventRoomStock:
+    RequestEventStock:
       type: object
       description: 既存の部屋を使う
       properties:
@@ -758,7 +758,7 @@ components:
     RequestEvent:
       oneOf:
         - $ref: "#/components/schemas/RequestEventInstant"
-        - $ref: "#/components/schemas/RequestEventRoomStock"
+        - $ref: "#/components/schemas/RequestEventStock"
     duration:
       type: object
       properties:


### PR DESCRIPTION
openapi-generatorのtypescript-axiosがoneOfなschemaをインラインで書いているのをうまく処理してくれないようです.
なので`RequestEventInstant`と`RequestEvent`のoneOfをしたschemaとして新しく`RequestEventAll`を作ってそれを使うようにしました．名前が適当なのでWIPにしてます