### PR TITLE
🐛 説明がないときに空の引用が webhook に含まれてた

### DIFF
--- a/router/middleware.go
+++ b/router/middleware.go
@@ -215,7 +215,11 @@ func (h *Handlers) WebhookEventHandler(c echo.Context, reqBody, resBody []byte) 
 		content += "\n\n\n"
 	}
 
-	content += "> " + strings.ReplaceAll(e.Description, "\n", "\n> ")
+	if strings.TrimSpace(e.Description) != "" {
+		content += "> " + strings.ReplaceAll(e.Description, "\n", "\n> ")
+	} else {
+		content = strings.TrimRight(content, "\n")
+	}
 
 	_ = utils.RequestWebhook(content, h.WebhookSecret, h.ActivityChannelID, h.WebhookID, 1)
 }


### PR DESCRIPTION
https://q.trap.jp/messages/ebebcb7a-7e1c-4026-a7c8-7adf99cd5f4b
とかで `>` が表示されてた
webhook のテストの仕方がわかんなくてテストできてないです
仕様だったりしたら蹴ってください