### PR TITLE
Set log level of gorm via environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       TOKEN_KEY: ${TOKEN_KEY:-random32wordsXXXXXXXXXXXXXXXXXXX}
       KNOQ_VERSION: ${KNOQ_VERSION:-dev}
       DEVELOPMENT: true
+      GORM_LOG_LEVEL: info
     volumes:
       - ./main.go:/srv/knoq/main.go
       - ./logging:/srv/knoq/logging

--- a/infra/db/db.go
+++ b/infra/db/db.go
@@ -6,6 +6,7 @@ import (
 	"github.com/traPtitech/knoQ/migration"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 // GormRepository implements domain
@@ -15,7 +16,21 @@ type GormRepository struct {
 
 var tokenKey []byte
 
-func (repo *GormRepository) Setup(host, user, password, database, key string) error {
+func (repo *GormRepository) Setup(host, user, password, database, key, logLevel string) error {
+	loglevel := func() logger.LogLevel {
+		switch logLevel {
+		case "slient":
+			return logger.Silent
+		case "error":
+			return logger.Error
+		case "info":
+			return logger.Info
+		case "warn":
+			return logger.Warn
+		default:
+			return logger.Silent
+		}
+	}()
 	if host == "" {
 		host = "mysql"
 	}
@@ -41,7 +56,9 @@ func (repo *GormRepository) Setup(host, user, password, database, key string) er
 		DontSupportRenameIndex:    true,  // drop & create when rename index, rename index not supported before MySQL 5.7, MariaDB
 		DontSupportRenameColumn:   false, // `change` when rename column, rename column not supported before MySQL 8, MariaDB
 		SkipInitializeWithVersion: false, // auto configure based on currently MySQL version
-	}), &gorm.Config{})
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(loglevel),
+	})
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	gormRepo := db.GormRepository{}
 	err := gormRepo.Setup(os.Getenv("MARIADB_HOSTNAME"), os.Getenv("MARIADB_USERNAME"),
-		os.Getenv("MARIADB_PASSWORD"), os.Getenv("MARIADB_DATABASE"), os.Getenv("TOKEN_KEY"))
+		os.Getenv("MARIADB_PASSWORD"), os.Getenv("MARIADB_DATABASE"), os.Getenv("TOKEN_KEY"), os.Getenv("GORM_LOG_LEVEL"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
環境変数を用いてGormのログレベルを切り替えられるようにしました。
https://github.com/traPtitech/knoQ/issues/394

現在は`info`に設定してあり、ドキュメントが正しければすべてのクエリが出力されるはずです。
https://gorm.io/ja_JP/docs/logger.html