### PR TITLE
:wrench: use golangci latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,4 @@ jobs:
           go-version-file: ./go.mod
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: 'v1.52.2' # https://github.com/golangci/golangci-lint-action/issues/759
           args: '--timeout=1m --verbose'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
           go-version-file: ./go.mod
       - uses: golangci/golangci-lint-action@v3
         with:
-          args: '--timeout=1m --verbose'
+          args: '--timeout=5m'


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.53.1 がリリースされてv1.53.0のバグが治った
