### PR TITLE
fix issue399

### DIFF
--- a/router/middleware.go
+++ b/router/middleware.go
@@ -200,35 +200,35 @@ func (h *Handlers) WebhookEventHandler(c echo.Context, reqBody, resBody []byte) 
 		return
 	}
 
-	if e.TimeEnd.After(time.Now()) {
-		// TODO fix: IDを環境変数などで定義すべき
-		traPGroupID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
-		if e.Group.ID == traPGroupID {
-			repo, ok := h.Repo.(*production.Repository)
-			if !ok {
-				return
+
+	// TODO fix: IDを環境変数などで定義すべき
+	traPGroupID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	if e.Group.ID == traPGroupID {
+		repo, ok := h.Repo.(*production.Repository)
+		if !ok {
+			return
+		}
+		t, err := repo.GormRepo.GetToken(getConinfo(c).ReqUserID)
+		if err != nil {
+			return
+		}
+		groups, _ := repo.TraQRepo.GetAllGroups(t)
+		for _, g := range groups {
+			if g.Type == "grade" {
+				nofiticationTargets = append(nofiticationTargets, g.Name)
 			}
-			t, err := repo.GormRepo.GetToken(getConinfo(c).ReqUserID)
-			if err != nil {
-				return
-			}
-			groups, _ := repo.TraQRepo.GetAllGroups(t)
-			for _, g := range groups {
-				if g.Type == "grade" {
-					nofiticationTargets = append(nofiticationTargets, g.Name)
-				}
-			}
-		} else {
-			for _, attendee := range e.Attendees {
-				if attendee.Schedule == presentation.Pending {
-					user, ok := usersMap[attendee.ID]
-					if ok {
-						nofiticationTargets = append(nofiticationTargets, user.Name)
-					}
+		}
+	} else {
+		for _, attendee := range e.Attendees {
+			if attendee.Schedule == presentation.Pending {
+				user, ok := usersMap[attendee.ID]
+				if ok {
+					nofiticationTargets = append(nofiticationTargets, user.Name)
 				}
 			}
 		}
 	}
+
 
 	content := presentation.GenerateEventWebhookContent(c.Request().Method, e, nofiticationTargets, h.Origin, !domain.DEVELOPMENT)
 

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -200,7 +200,6 @@ func (h *Handlers) WebhookEventHandler(c echo.Context, reqBody, resBody []byte) 
 		return
 	}
 
-
 	// TODO fix: IDを環境変数などで定義すべき
 	traPGroupID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
 	if e.Group.ID == traPGroupID {
@@ -228,7 +227,6 @@ func (h *Handlers) WebhookEventHandler(c echo.Context, reqBody, resBody []byte) 
 			}
 		}
 	}
-
 
 	content := presentation.GenerateEventWebhookContent(c.Request().Method, e, nofiticationTargets, h.Origin, !domain.DEVELOPMENT)
 

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -196,7 +196,11 @@ func (h *Handlers) WebhookEventHandler(c echo.Context, reqBody, resBody []byte) 
 	usersMap := createUserMap(users)
 	nofiticationTargets := make([]string, 0)
 
-	if e.TimeStart.After(time.Now()) {
+	if e.TimeEnd.Before(time.Now()) {
+		return
+	}
+
+	if e.TimeEnd.After(time.Now()) {
 		// TODO fix: IDを環境変数などで定義すべき
 		traPGroupID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
 		if e.Group.ID == traPGroupID {


### PR DESCRIPTION
1.イベントが終了後である ( TimeEnd.before(time.Now()) が true である ) ときに router/middleware.go WebhookEventHandlerで utils.RequestWebhook を呼ばない(通知をtraQに投稿しない) ようにしました。
2.これに関連して、同関数内でメンションする対象を取得する処理の実行条件を 「イベントが開始前である」→「イベントが終了前である」に変更しました。
1についてはこれで良いと考えていますが、2の変更はあってもなくても良いと考えています。