### PR TITLE
Fix/issue439 traQへのリクエストにgo-traqを使う GroupAPI

### DIFF
--- a/infra/traq/group.go
+++ b/infra/traq/group.go
@@ -25,7 +25,6 @@ func (repo *TraQRepository) GetGroup(token *oauth2.Token, groupID uuid.UUID) (*t
 
 	// group := new(traq.UserGroup)
 	// err = json.Unmarshal(data, &group)
-	// fmt.Println("GetGroup")
 	ctx := context.TODO()
 	apiClient := NewAPIClient(ctx, token)
 	group, resp, err := apiClient.GroupApi.GetUserGroup(ctx, groupID.String()).Execute()
@@ -36,24 +35,38 @@ func (repo *TraQRepository) GetGroup(token *oauth2.Token, groupID uuid.UUID) (*t
 	if err != nil {
 		return nil, err
 	}
-	// fmt.Println("GetOK")
 	return group, err
 }
 
 func (repo *TraQRepository) GetAllGroups(token *oauth2.Token) ([]*traq.UserGroup, error) {
-	URL := fmt.Sprintf("%s/groups", repo.URL)
-	req, err := http.NewRequest(http.MethodGet, URL, nil)
-	if err != nil {
-		return nil, err
-	}
-	data, err := repo.doRequest(token, req)
-	if err != nil {
-		return nil, err
-	}
+	// URL := fmt.Sprintf("%s/groups", repo.URL)
+	// req, err := http.NewRequest(http.MethodGet, URL, nil)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// data, err := repo.doRequest(token, req)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	groups := make([]*traq.UserGroup, 0)
-	err = json.Unmarshal(data, &groups)
-	return groups, err
+	// groups := make([]*traq.UserGroup, 0)
+	// err = json.Unmarshal(data, &groups)
+	ctx := context.TODO()
+	apiClient := NewAPIClient(ctx, token)
+	groups, resp, err := apiClient.GroupApi.GetUserGroups(ctx).Execute()
+	if err != nil {
+		return nil, err
+	}
+	err = handleStatusCode(resp.StatusCode)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]*traq.UserGroup, len(groups))
+	for i, _g := range groups {
+		g := _g
+		ret[i] = &g
+	}
+	return ret, err
 }
 
 func (repo *TraQRepository) GetUserBelongingGroupIDs(token *oauth2.Token, userID uuid.UUID) ([]uuid.UUID, error) {

--- a/infra/traq/group.go
+++ b/infra/traq/group.go
@@ -23,7 +23,7 @@ func (repo *TraQRepository) GetGroup(token *oauth2.Token, groupID uuid.UUID) (*t
 	return group, err
 }
 
-func (repo *TraQRepository) GetAllGroups(token *oauth2.Token) ([]*traq.UserGroup, error) {
+func (repo *TraQRepository) GetAllGroups(token *oauth2.Token) ([]traq.UserGroup, error) {
 	ctx := context.TODO()
 	apiClient := NewAPIClient(ctx, token)
 	groups, resp, err := apiClient.GroupApi.GetUserGroups(ctx).Execute()
@@ -34,12 +34,7 @@ func (repo *TraQRepository) GetAllGroups(token *oauth2.Token) ([]*traq.UserGroup
 	if err != nil {
 		return nil, err
 	}
-	ret := make([]*traq.UserGroup, len(groups))
-	for i, _g := range groups {
-		g := _g
-		ret[i] = &g
-	}
-	return ret, err
+	return groups, err
 }
 
 func (repo *TraQRepository) GetUserBelongingGroupIDs(token *oauth2.Token, userID uuid.UUID) ([]uuid.UUID, error) {

--- a/infra/traq/group.go
+++ b/infra/traq/group.go
@@ -1,6 +1,7 @@
 package traq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,18 +13,30 @@ import (
 )
 
 func (repo *TraQRepository) GetGroup(token *oauth2.Token, groupID uuid.UUID) (*traq.UserGroup, error) {
-	URL := fmt.Sprintf("%s/groups/%s", repo.URL, groupID)
-	req, err := http.NewRequest(http.MethodGet, URL, nil)
-	if err != nil {
-		return nil, err
-	}
-	data, err := repo.doRequest(token, req)
-	if err != nil {
-		return nil, err
-	}
+	// URL := fmt.Sprintf("%s/groups/%s", repo.URL, groupID)
+	// req, err := http.NewRequest(http.MethodGet, URL, nil)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// data, err := repo.doRequest(token, req)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	group := new(traq.UserGroup)
-	err = json.Unmarshal(data, &group)
+	// group := new(traq.UserGroup)
+	// err = json.Unmarshal(data, &group)
+	// fmt.Println("GetGroup")
+	ctx := context.TODO()
+	apiClient := NewAPIClient(ctx, token)
+	group, resp, err := apiClient.GroupApi.GetUserGroup(ctx, groupID.String()).Execute()
+	if err != nil {
+		return nil, err
+	}
+	err = handleStatusCode(resp.StatusCode)
+	if err != nil {
+		return nil, err
+	}
+	// fmt.Println("GetOK")
 	return group, err
 }
 

--- a/infra/traq/group.go
+++ b/infra/traq/group.go
@@ -2,9 +2,6 @@ package traq
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
 
 	"github.com/gofrs/uuid"
 	"golang.org/x/oauth2"
@@ -70,17 +67,27 @@ func (repo *TraQRepository) GetAllGroups(token *oauth2.Token) ([]*traq.UserGroup
 }
 
 func (repo *TraQRepository) GetUserBelongingGroupIDs(token *oauth2.Token, userID uuid.UUID) ([]uuid.UUID, error) {
-	URL := fmt.Sprintf("%s/users/%s", repo.URL, userID)
-	req, err := http.NewRequest(http.MethodGet, URL, nil)
+	// URL := fmt.Sprintf("%s/users/%s", repo.URL, userID)
+	// req, err := http.NewRequest(http.MethodGet, URL, nil)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// data, err := repo.doRequest(token, req)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// user := new(traq.UserDetail)
+	// if err := json.Unmarshal(data, &user); err != nil {
+	// 	return nil, err
+	// }
+	ctx := context.TODO()
+	apiClient := NewAPIClient(ctx, token)
+	user, resp, err := apiClient.UserApi.GetUser(ctx, userID.String()).Execute()
 	if err != nil {
 		return nil, err
 	}
-	data, err := repo.doRequest(token, req)
+	err = handleStatusCode(resp.StatusCode)
 	if err != nil {
-		return nil, err
-	}
-	user := new(traq.UserDetail)
-	if err := json.Unmarshal(data, &user); err != nil {
 		return nil, err
 	}
 	groups := make([]uuid.UUID, 0, len(user.Groups))

--- a/infra/traq/group.go
+++ b/infra/traq/group.go
@@ -10,18 +10,6 @@ import (
 )
 
 func (repo *TraQRepository) GetGroup(token *oauth2.Token, groupID uuid.UUID) (*traq.UserGroup, error) {
-	// URL := fmt.Sprintf("%s/groups/%s", repo.URL, groupID)
-	// req, err := http.NewRequest(http.MethodGet, URL, nil)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// data, err := repo.doRequest(token, req)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// group := new(traq.UserGroup)
-	// err = json.Unmarshal(data, &group)
 	ctx := context.TODO()
 	apiClient := NewAPIClient(ctx, token)
 	group, resp, err := apiClient.GroupApi.GetUserGroup(ctx, groupID.String()).Execute()
@@ -36,18 +24,6 @@ func (repo *TraQRepository) GetGroup(token *oauth2.Token, groupID uuid.UUID) (*t
 }
 
 func (repo *TraQRepository) GetAllGroups(token *oauth2.Token) ([]*traq.UserGroup, error) {
-	// URL := fmt.Sprintf("%s/groups", repo.URL)
-	// req, err := http.NewRequest(http.MethodGet, URL, nil)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// data, err := repo.doRequest(token, req)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// groups := make([]*traq.UserGroup, 0)
-	// err = json.Unmarshal(data, &groups)
 	ctx := context.TODO()
 	apiClient := NewAPIClient(ctx, token)
 	groups, resp, err := apiClient.GroupApi.GetUserGroups(ctx).Execute()
@@ -67,19 +43,6 @@ func (repo *TraQRepository) GetAllGroups(token *oauth2.Token) ([]*traq.UserGroup
 }
 
 func (repo *TraQRepository) GetUserBelongingGroupIDs(token *oauth2.Token, userID uuid.UUID) ([]uuid.UUID, error) {
-	// URL := fmt.Sprintf("%s/users/%s", repo.URL, userID)
-	// req, err := http.NewRequest(http.MethodGet, URL, nil)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// data, err := repo.doRequest(token, req)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// user := new(traq.UserDetail)
-	// if err := json.Unmarshal(data, &user); err != nil {
-	// 	return nil, err
-	// }
 	ctx := context.TODO()
 	apiClient := NewAPIClient(ctx, token)
 	user, resp, err := apiClient.UserApi.GetUser(ctx, userID.String()).Execute()
@@ -98,6 +61,5 @@ func (repo *TraQRepository) GetUserBelongingGroupIDs(token *oauth2.Token, userID
 		}
 		groups = append(groups, groupUUID)
 	}
-
 	return groups, err
 }

--- a/infra/traq/traq.go
+++ b/infra/traq/traq.go
@@ -5,8 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
-	"io"
-	"net/http"
 	"net/url"
 
 	"github.com/traPtitech/go-traq"
@@ -64,19 +62,6 @@ func (repo *TraQRepository) GetOAuthToken(query, state, codeVerifier string) (*o
 	code := values.Get("code")
 	option := oauth2.SetAuthURLParam("code_verifier", codeVerifier)
 	return repo.Config.Exchange(ctx, code, option)
-}
-
-func (repo *TraQRepository) doRequest(token *oauth2.Token, req *http.Request) ([]byte, error) {
-	client := repo.Config.Client(context.TODO(), token)
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	err = handleStatusCode(resp.StatusCode)
-	if err != nil {
-		return nil, err
-	}
-	return io.ReadAll(resp.Body)
 }
 
 func NewAPIClient(ctx context.Context, token *oauth2.Token) *traq.APIClient {

--- a/repository/converter.go
+++ b/repository/converter.go
@@ -18,7 +18,7 @@ func ConvSPtraqUserGroupToSPdomainGroup(src []traq.UserGroup) (dst []*domain.Gro
 	dst = make([]*domain.Group, len(src))
 	for i := range src {
 		dst[i] = new(domain.Group)
-		(*dst[i]) = ConvtraqUserGroupTodomainGroup((src[i]))
+		(*dst[i]) = ConvtraqUserGroupTodomainGroup(src[i])
 	}
 	return
 }

--- a/repository/converter.go
+++ b/repository/converter.go
@@ -14,13 +14,11 @@ func ConvPtraqUserToPdomainUser(src *traq.User) (dst *domain.User) {
 	return
 }
 
-func ConvSPtraqUserGroupToSPdomainGroup(src []*traq.UserGroup) (dst []*domain.Group) {
+func ConvSPtraqUserGroupToSPdomainGroup(src []traq.UserGroup) (dst []*domain.Group) {
 	dst = make([]*domain.Group, len(src))
 	for i := range src {
-		if src[i] != nil {
-			dst[i] = new(domain.Group)
-			(*dst[i]) = ConvtraqUserGroupTodomainGroup((*src[i]))
-		}
+		dst[i] = new(domain.Group)
+		(*dst[i]) = ConvtraqUserGroupTodomainGroup((src[i]))
 	}
 	return
 }


### PR DESCRIPTION
infra/traq/group.go 内のtraQのAPIを呼んでいるコードをgo-traqを使うものに書き換えました。
GetAllGroupsの戻り値の型を `[]*traq.UserGroup` から `[]traq.UserGroup` に変えたため、この関数を使っているrepository/converter.goにも変更を加えました。

infra/traq/traq.goの`doRequest`が使われている箇所がなくなりました。