### PR TITLE
:bug: added migrate v13.go to drop constraint `UNIQUE(name, time_star…

### DIFF
--- a/migration/current.go
+++ b/migration/current.go
@@ -19,5 +19,6 @@ func Migrations() []*gormigrate.Migration {
 		v10(),
 		v11(),
 		v12(),
+		v13(),
 	}
 }

--- a/migration/v13.go
+++ b/migration/v13.go
@@ -1,0 +1,15 @@
+package migration
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func v13() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "13",
+		Migrate: func(db *gorm.DB) error {
+			return db.Exec("ALTER TABLE events DROP CONSTRAINT UNIQUE(name, time_start, time_end)").Error
+		},
+	}
+}


### PR DESCRIPTION
…t, time_end)` from `events` table.
- close #543 