### PR TITLE
:art: remove NewOAuthAPI function, remove HTTPClient field's assignment

### DIFF
--- a/infra/traq/group.go
+++ b/infra/traq/group.go
@@ -40,8 +40,8 @@ func (repo *TraQRepository) GetAllGroups() ([]traq.UserGroup, error) {
 }
 
 func (repo *TraQRepository) GetUserBelongingGroupIDs(token *oauth2.Token, userID uuid.UUID) ([]uuid.UUID, error) {
-	ctx := context.TODO()
-	apiClient := NewOauth2APIClient(ctx, token)
+	ctx := context.WithValue(context.TODO(), traq.ContextAccessToken, token.AccessToken)
+	apiClient := traq.NewAPIClient(traqAPIConfig)
 	user, resp, err := apiClient.UserApi.GetUser(ctx, userID.String()).Execute()
 	if err != nil {
 		return nil, err

--- a/infra/traq/traq.go
+++ b/infra/traq/traq.go
@@ -19,17 +19,6 @@ type TraQRepository struct {
 	ServerAccessToken string
 }
 
-var TraQDefaultConfig = &oauth2.Config{
-	ClientID:     "something",
-	ClientSecret: "any",
-	RedirectURL:  "foo",
-	Scopes:       []string{"read", "write", "manage_bot"},
-	Endpoint: oauth2.Endpoint{
-		AuthURL:  "https://q.trap.jp/api/v3/oauth2/authorize",
-		TokenURL: "https://q.trap.jp/api/v3/oauth2/token",
-	},
-}
-
 var traqAPIConfig = traq.NewConfiguration()
 
 func newPKCE() (pkceOptions []oauth2.AuthCodeOption, codeVerifier string) {
@@ -65,12 +54,4 @@ func (repo *TraQRepository) GetOAuthToken(query, state, codeVerifier string) (*o
 	code := values.Get("code")
 	option := oauth2.SetAuthURLParam("code_verifier", codeVerifier)
 	return repo.Config.Exchange(ctx, code, option)
-}
-
-func NewOauth2APIClient(ctx context.Context, token *oauth2.Token) *traq.APIClient {
-	traqconf := traqAPIConfig
-	conf := TraQDefaultConfig
-	traqconf.HTTPClient = conf.Client(ctx, token)
-	apiClient := traq.NewAPIClient(traqconf)
-	return apiClient
 }

--- a/infra/traq/user.go
+++ b/infra/traq/user.go
@@ -48,8 +48,8 @@ func (repo *TraQRepository) GetUsers(includeSuspended bool) ([]traq.User, error)
 }
 
 func (repo *TraQRepository) GetUserMe(token *oauth2.Token) (*traq.User, error) {
-	ctx := context.TODO()
-	apiClient := NewOauth2APIClient(ctx, token)
+	ctx := context.WithValue(context.TODO(), traq.ContextAccessToken, token.AccessToken)
+	apiClient := traq.NewAPIClient(traqAPIConfig)
 	userDetail, resp, err := apiClient.MeApi.GetMe(ctx).Execute()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`HTTPClient` フィールドを書き換える処理が原因で不具合が起きていることが確認できたので
`HTTPClient` フィールドを書き換えないような処理に変更しました．