### PR TITLE
fix:eventの取得ロジックの時間フィルタを変更

### DIFF
--- a/domain/filter/shorthand.go
+++ b/domain/filter/shorthand.go
@@ -55,6 +55,23 @@ func FilterTime(start, end time.Time) Expr {
 		return nil
 	}
 
+	// startがゼロの時はend以前に一部でもイベントが含まれるものを返す
+	if start.IsZero() {
+		return &CmpExpr{
+			Attr:     AttrTimeStart,
+			Relation: LessEq,
+			Value:    end,
+		}
+	}
+	// endがゼロの時はstart以降に一部でもイベントが含まれるものを返す
+	if end.IsZero() {
+		return &CmpExpr{
+			Attr:     AttrTimeEnd,
+			Relation: GreterEq,
+			Value:    start,
+		}
+	}
+
 	// イベント開始時刻が指定された範囲内にあるか
 	eventStartInRangeRight := &CmpExpr{
 		Attr:     AttrTimeStart,
@@ -113,6 +130,7 @@ func FilterTime(start, end time.Time) Expr {
 		},
 	}
 }
+
 func AddAnd(lhs, rhs Expr) Expr {
 	if lhs == nil && rhs == nil {
 		return nil

--- a/domain/filter/shorthand.go
+++ b/domain/filter/shorthand.go
@@ -54,80 +54,27 @@ func FilterTime(start, end time.Time) Expr {
 	if start.IsZero() && end.IsZero() {
 		return nil
 	}
+	timeStart := &CmpExpr{
+		Attr:     AttrTimeStart,
+		Relation: GreterEq,
+		Value:    start,
+	}
+	timeEnd := &CmpExpr{
+		Attr:     AttrTimeEnd,
+		Relation: LessEq,
+		Value:    end,
+	}
 
-	// startがゼロの時はend以前に一部でもイベントが含まれるものを返す
 	if start.IsZero() {
-		return &CmpExpr{
-			Attr:     AttrTimeStart,
-			Relation: LessEq,
-			Value:    end,
-		}
+		return timeEnd
 	}
-	// endがゼロの時はstart以降に一部でもイベントが含まれるものを返す
 	if end.IsZero() {
-		return &CmpExpr{
-			Attr:     AttrTimeEnd,
-			Relation: GreterEq,
-			Value:    start,
-		}
+		return timeStart
 	}
-
-	// イベント開始時刻が指定された範囲内にあるか
-	eventStartInRangeRight := &CmpExpr{
-		Attr:     AttrTimeStart,
-		Relation: LessEq,
-		Value:    end,
-	}
-	eventStartInRangeLeft := &CmpExpr{
-		Attr:     AttrTimeStart,
-		Relation: GreterEq,
-		Value:    start,
-	}
-
-	// イベント終了時刻が指定された範囲内にあるか
-	eventEndInRangeRight := &CmpExpr{
-		Attr:     AttrTimeEnd,
-		Relation: LessEq,
-		Value:    end,
-	}
-	eventEndInRangeLeft := &CmpExpr{
-		Attr:     AttrTimeEnd,
-		Relation: GreterEq,
-		Value:    start,
-	}
-
-	// イベントの開催期間が指定された範囲を包含しているか
-	eventStartBeforeRangeStart := &CmpExpr{
-		Attr:     AttrTimeStart,
-		Relation: LessEq,
-		Value:    start,
-	}
-	eventEndAfterRangeEnd := &CmpExpr{
-		Attr:     AttrTimeEnd,
-		Relation: GreterEq,
-		Value:    end,
-	}
-
 	return &LogicOpExpr{
-		LogicOp: Or,
-		Lhs: &LogicOpExpr{
-			LogicOp: Or,
-			Lhs: &LogicOpExpr{
-				LogicOp: And,
-				Lhs:     eventStartInRangeRight,
-				Rhs:     eventStartInRangeLeft,
-			},
-			Rhs: &LogicOpExpr{
-				LogicOp: And,
-				Lhs:     eventEndInRangeRight,
-				Rhs:     eventEndInRangeLeft,
-			},
-		},
-		Rhs: &LogicOpExpr{
-			LogicOp: And,
-			Lhs:     eventStartBeforeRangeStart,
-			Rhs:     eventEndAfterRangeEnd,
-		},
+		LogicOp: And,
+		Lhs:     timeStart,
+		Rhs:     timeEnd,
 	}
 }
 

--- a/router/events.go
+++ b/router/events.go
@@ -91,9 +91,15 @@ func (h *Handlers) HandleGetEvents(c echo.Context) error {
 	if err != nil {
 		return badRequest(err, message("invalid time"))
 	}
-	events, err := h.Repo.GetEvents(
-		filter.AddAnd(expr, filter.FilterTime(start, end)),
-		getConinfo(c))
+
+	durationExpr, err := filter.FilterDuration(start, end)
+	if err != nil {
+		return badRequest(err, message("filter duration error"))
+	}
+
+	combinedExpr := filter.AddAnd(expr, durationExpr)
+
+	events, err := h.Repo.GetEvents(combinedExpr, getConinfo(c))
 	if err != nil {
 		return judgeErrorResponse(err)
 	}


### PR DESCRIPTION
close #570
複数日開催のイベントの取得に対応するため，FilterTime関数を
「イベントの開催日が指定範囲に入っている」または「イベントの終了日が指定範囲に入っている」または「イベントの開催期間が指定範囲を包含している」
という条件にしました。(指定範囲とはdateStart以上dateEnd以下のこと)