### PR TITLE
event取得系のエンドポイントで開始時刻と終了時刻をクエリパラメタで指定できるようにする

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -274,6 +274,8 @@ paths:
         - events
       parameters:
         - $ref: '#/components/parameters/userRelation'
+        - $ref: '#/components/parameters/dateBegin'
+        - $ref: '#/components/parameters/dateEnd'
       operationId: getMyEvents
       description: 所属しているイベントを返す
       responses:
@@ -287,6 +289,8 @@ paths:
         - events
       parameters:
         - $ref: '#/components/parameters/userRelation'
+        - $ref: '#/components/parameters/dateBegin'
+        - $ref: '#/components/parameters/dateEnd'
       operationId: getUserEvents
       description: 所属しているイベントを返す
       responses:
@@ -299,6 +303,9 @@ paths:
     get:
       tags:
         - events
+      parameters:
+        - $ref: '#/components/parameters/dateBegin'
+        - $ref: '#/components/parameters/dateEnd'
       operationId: getEventsOfRoom
       description: 指定した部屋で行われるイベントを返す
       responses:
@@ -310,6 +317,9 @@ paths:
     get:
       tags:
         - events
+      parameters:
+        - $ref: '#/components/parameters/dateBegin'
+        - $ref: '#/components/parameters/dateEnd'
       operationId: getEventsOfGroup
       description: groupIdのeventsを取得
       responses:

--- a/router/events.go
+++ b/router/events.go
@@ -115,8 +115,24 @@ func (h *Handlers) HandleGetEventsByGroupID(c echo.Context) error {
 	if err != nil {
 		return notFound(err)
 	}
-	events, err := h.Repo.GetEvents(filters.FilterGroupIDs(groupID),
-		getConinfo(c))
+
+	values := c.QueryParams()
+
+	groupExpr := filters.FilterGroupIDs(groupID)
+
+	start, end, err := presentation.GetTiemRange(values)
+	if err != nil {
+		return badRequest(err, message("invalid time"))
+	}
+
+	durationExpr, err := filters.FilterDuration(start, end)
+	if err != nil {
+		return badRequest(err, message("filter duration error"))
+	}
+
+	combinedExpr := filters.AddAnd(groupExpr, durationExpr)
+
+	events, err := h.Repo.GetEvents(combinedExpr, getConinfo(c))
 	if err != nil {
 		return judgeErrorResponse(err)
 	}
@@ -184,9 +200,23 @@ func (h *Handlers) HandleGetMeEvents(c echo.Context) error {
 		return notFound(err)
 	}
 
-	events, err := h.Repo.GetEvents(
-		getUserRelationFilter(c.QueryParams(), userID),
-		getConinfo(c))
+	values := c.QueryParams()
+
+	relationExpr := getUserRelationFilter(values, userID)
+
+	start, end, err := presentation.GetTiemRange(values)
+	if err != nil {
+		return badRequest(err, message("invalid time"))
+	}
+
+	durationExpr, err := filters.FilterDuration(start, end)
+	if err != nil {
+		return badRequest(err, message("filter duration error"))
+	}
+
+	combinedExpr := filters.AddAnd(relationExpr, durationExpr)
+
+	events, err := h.Repo.GetEvents(combinedExpr, getConinfo(c))
 	if err != nil {
 		return judgeErrorResponse(err)
 	}
@@ -200,9 +230,23 @@ func (h *Handlers) HandleGetEventsByUserID(c echo.Context) error {
 		return notFound(err)
 	}
 
-	events, err := h.Repo.GetEvents(
-		getUserRelationFilter(c.QueryParams(), userID),
-		getConinfo(c))
+	values := c.QueryParams()
+
+	relationExpr := getUserRelationFilter(values, userID)
+
+	start, end, err := presentation.GetTiemRange(values)
+	if err != nil {
+		return badRequest(err, message("invalid time"))
+	}
+
+	durationExpr, err := filters.FilterDuration(start, end)
+	if err != nil {
+		return badRequest(err, message("filter duration error"))
+	}
+
+	combinedExpr := filters.AddAnd(relationExpr, durationExpr)
+
+	events, err := h.Repo.GetEvents(combinedExpr, getConinfo(c))
 	if err != nil {
 		return judgeErrorResponse(err)
 	}
@@ -218,8 +262,24 @@ func (h *Handlers) HandleGetEventsByRoomID(c echo.Context) error {
 		return notFound(err)
 	}
 
+	values := c.QueryParams()
+
+	roomExpr := filters.FilterRoomIDs(roomID)
+
+	start, end, err := presentation.GetTiemRange(values)
+	if err != nil {
+		return badRequest(err, message("invalid time"))
+	}
+
+	durationExpr, err := filters.FilterDuration(start, end)
+	if err != nil {
+		return badRequest(err, message("filter duration error"))
+	}
+
+	combinedExpr := filters.AddAnd(roomExpr, durationExpr)
+
 	events, err := h.Repo.GetEvents(
-		filters.FilterRoomIDs(roomID),
+		combinedExpr,
 		getConinfo(c),
 	)
 	if err != nil {

--- a/router/events.go
+++ b/router/events.go
@@ -86,13 +86,7 @@ func (h *Handlers) HandleGetEvents(c echo.Context) error {
 	if err != nil {
 		return badRequest(err, message("parse error"))
 	}
-
-	start, end, err := presentation.GetTiemRange(values)
-	if err != nil {
-		return badRequest(err, message("invalid time"))
-	}
-
-	durationExpr, err := filters.FilterDuration(start, end)
+	durationExpr, err := getDurationFilter(values)
 	if err != nil {
 		return badRequest(err, message("filter duration error"))
 	}
@@ -120,12 +114,7 @@ func (h *Handlers) HandleGetEventsByGroupID(c echo.Context) error {
 
 	groupExpr := filters.FilterGroupIDs(groupID)
 
-	start, end, err := presentation.GetTiemRange(values)
-	if err != nil {
-		return badRequest(err, message("invalid time"))
-	}
-
-	durationExpr, err := filters.FilterDuration(start, end)
+	durationExpr, err := getDurationFilter(values)
 	if err != nil {
 		return badRequest(err, message("filter duration error"))
 	}
@@ -204,12 +193,7 @@ func (h *Handlers) HandleGetMeEvents(c echo.Context) error {
 
 	relationExpr := getUserRelationFilter(values, userID)
 
-	start, end, err := presentation.GetTiemRange(values)
-	if err != nil {
-		return badRequest(err, message("invalid time"))
-	}
-
-	durationExpr, err := filters.FilterDuration(start, end)
+	durationExpr, err := getDurationFilter(values)
 	if err != nil {
 		return badRequest(err, message("filter duration error"))
 	}
@@ -234,12 +218,7 @@ func (h *Handlers) HandleGetEventsByUserID(c echo.Context) error {
 
 	relationExpr := getUserRelationFilter(values, userID)
 
-	start, end, err := presentation.GetTiemRange(values)
-	if err != nil {
-		return badRequest(err, message("invalid time"))
-	}
-
-	durationExpr, err := filters.FilterDuration(start, end)
+	durationExpr, err := getDurationFilter(values)
 	if err != nil {
 		return badRequest(err, message("filter duration error"))
 	}
@@ -266,12 +245,7 @@ func (h *Handlers) HandleGetEventsByRoomID(c echo.Context) error {
 
 	roomExpr := filters.FilterRoomIDs(roomID)
 
-	start, end, err := presentation.GetTiemRange(values)
-	if err != nil {
-		return badRequest(err, message("invalid time"))
-	}
-
-	durationExpr, err := filters.FilterDuration(start, end)
+	durationExpr, err := getDurationFilter(values)
 	if err != nil {
 		return badRequest(err, message("filter duration error"))
 	}

--- a/router/utils.go
+++ b/router/utils.go
@@ -28,3 +28,17 @@ func createUserMap(users []*domain.User) map[uuid.UUID]*domain.User {
 	}
 	return userMap
 }
+
+func getDurationFilter(values url.Values) (filters.Expr, error) {
+	start, end, err := presentation.GetTiemRange(values)
+	if err != nil {
+		return nil, err
+	}
+
+	durationExpr, err := filters.FilterDuration(start, end)
+	if err != nil {
+		return nil, err
+	}
+
+	return durationExpr, nil
+}


### PR DESCRIPTION
event取得系のエンドポイントで開始時刻と終了時刻をクエリパラメタで指定できるようにしました。これは，フロント側のissue https://github.com/traPtitech/knoQ-UI/issues/1007 に取り組む際に，`/events`以外のevent取得エンドポイントにも時刻による絞り込みがあっても良いと考えたからです。(少なくとも1007の解決のためには`/users/me/events`には必要です。)