### PR TITLE
Fix/too many groups event 591

### DIFF
--- a/repository/group.go
+++ b/repository/group.go
@@ -192,7 +192,7 @@ func (repo *Repository) GetGradeGroupNames(_ *domain.ConInfo) ([]string, error) 
 		return nil, defaultErrorHandling(err)
 	}
 
-	// 凍結されたグループメンバーのみのmapを作成
+	// アクティブユーザーのみのmapを作成
 	activeUsersID, err := repo.TraQRepo.GetUsers(false)
 	if err != nil {
 		return nil, defaultErrorHandling(err)


### PR DESCRIPTION
# 概要
全員参加イベントのグループの量が多いの修正 #591

# 動作確認の手順
http://localhost:3000/api/events をgroupIdを`11111111-1111-1111-1111-111111111111`にしてPOSTで叩き、`GetGradeGroupNames`でデバッグ出力するとわかる

# 補足
`len(g.Members) != 0`だと、凍結済みのメンバーのみのグループも入ってしまうため`GetUsers`を使いました
https://github.com/traPtitech/knoQ/blob/cc1819eb557270327d624e07b61c875405437f73/repository/group.go#L190-L206
