### PR TITLE
Refactor Repositoryのinterface化

### DIFF
--- a/infra/db/db.go
+++ b/infra/db/db.go
@@ -4,20 +4,68 @@ import (
 	"time"
 
 	gomysql "github.com/go-sql-driver/mysql"
+	"github.com/gofrs/uuid"
+	"github.com/traPtitech/knoQ/domain"
+	"github.com/traPtitech/knoQ/domain/filters"
 	"github.com/traPtitech/knoQ/migration"
+	"golang.org/x/oauth2"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
-// GormRepository implements domain
-type GormRepository struct {
+// GormRepository
+
+type GormRepository interface {
+	Setup(host, user, password, database, port, key, logLevel string, loc *time.Location) error
+	CreateEvent(params WriteEventParams) (*Event, error)
+	UpdateEvent(eventID uuid.UUID, params WriteEventParams) (*Event, error)
+	AddEventTag(eventID uuid.UUID, params domain.EventTagParams) error
+	DeleteEvent(eventID uuid.UUID) error
+	DeleteEventTag(eventID uuid.UUID, tagName string, deleteLocked bool) error
+	UpsertEventSchedule(eventID, userID uuid.UUID, scheduleStatus domain.ScheduleStatus) error
+	GetEvent(eventID uuid.UUID) (*Event, error)
+	GetAllEvents(expr filters.Expr) ([]*Event, error)
+	CreateGroup(params WriteGroupParams) (*Group, error)
+	UpdateGroup(groupID uuid.UUID, params WriteGroupParams) (*Group, error)
+	AddMemberToGroup(groupID, userID uuid.UUID) error
+	DeleteGroup(groupID uuid.UUID) error
+	DeleteMemberOfGroup(groupID, userID uuid.UUID) error
+	GetGroup(groupID uuid.UUID) (*Group, error)
+	GetAllGroups() ([]*Group, error)
+	GetBelongGroupIDs(userID uuid.UUID) ([]uuid.UUID, error)
+	GetAdminGroupIDs(userID uuid.UUID) ([]uuid.UUID, error)
+	CreateRoom(params CreateRoomParams) (*domain.Room, error)
+	UpdateRoom(roomID uuid.UUID, params UpdateRoomParams) (*domain.Room, error)
+	UpdateRoomVerified(roomID uuid.UUID, verified bool) error
+	DeleteRoom(roomID uuid.UUID) error
+	GetRoom(roomID uuid.UUID, excludeEventID uuid.UUID) (*domain.Room, error)
+	GetAllRooms(start, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error)
+	CreateOrGetTag(name string) (*domain.Tag, error)
+	GetTag(tagID uuid.UUID) (*domain.Tag, error)
+	GetAllTags() ([]*domain.Tag, error)
+	GetToken(userID uuid.UUID) (*oauth2.Token, error)
+	SaveUser(user User) (*User, error)
+	UpdateiCalSecret(userID uuid.UUID, secret string) error
+	GetUser(userID uuid.UUID) (*User, error)
+	GetAllUsers(onlyActive bool) ([]*User, error)
+	SyncUsers(users []*User) error
+	GrantPrivilege(userID uuid.UUID) error
+}
+
+// structのポインタを返す
+func NewGormRepository() GormRepository {
+	gormrepo := gormRepository{}
+	return &gormrepo
+}
+
+type gormRepository struct {
 	db *gorm.DB
 }
 
 var tokenKey []byte
 
-func (repo *GormRepository) Setup(host, user, password, database, port, key, logLevel string, loc *time.Location) error {
+func (repo *gormRepository) Setup(host, user, password, database, port, key, logLevel string, loc *time.Location) error {
 	loglevel := func() logger.LogLevel {
 		switch logLevel {
 		case "slient":

--- a/infra/db/db_test.go
+++ b/infra/db/db_test.go
@@ -25,7 +25,7 @@ const (
 	dbHost = "localhost"
 )
 
-var repositories = map[string]*GormRepository{}
+var repositories = map[string]*gormRepository{}
 
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")
@@ -90,7 +90,7 @@ func TestMain(m *testing.M) {
 		if err := db.Migrator().AutoMigrate(tables...); err != nil {
 			panic(err)
 		}
-		repo := GormRepository{
+		repo := gormRepository{
 			db: db,
 		}
 		repositories[key] = &repo
@@ -109,7 +109,7 @@ func mustNewUUIDV4(t *testing.T) uuid.UUID {
 	return id
 }
 
-func setupRepo(t *testing.T, repo string) (*GormRepository, *assert.Assertions, *require.Assertions) {
+func setupRepo(t *testing.T, repo string) (*gormRepository, *assert.Assertions, *require.Assertions) {
 	t.Helper()
 	r, ok := repositories[repo]
 	if !ok {
@@ -119,28 +119,28 @@ func setupRepo(t *testing.T, repo string) (*GormRepository, *assert.Assertions, 
 	return r, assert, require
 }
 
-func setupRepoWithUser(t *testing.T, repo string) (*GormRepository, *assert.Assertions, *require.Assertions, *User) {
+func setupRepoWithUser(t *testing.T, repo string) (*gormRepository, *assert.Assertions, *require.Assertions, *User) {
 	t.Helper()
 	r, assert, require := setupRepo(t, repo)
 	user := mustMakeUser(t, r, false)
 	return r, assert, require, user
 }
 
-func setupRepoWithUserGroup(t *testing.T, repo string) (*GormRepository, *assert.Assertions, *require.Assertions, *User, *Group) {
+func setupRepoWithUserGroup(t *testing.T, repo string) (*gormRepository, *assert.Assertions, *require.Assertions, *User, *Group) {
 	t.Helper()
 	r, assert, require := setupRepo(t, repo)
 	group, user := mustMakeGroup(t, r, random.AlphaNumeric(10, false))
 	return r, assert, require, user, group
 }
 
-func setupRepoWithUserRoom(t *testing.T, repo string) (*GormRepository, *assert.Assertions, *require.Assertions, *User, *Room) {
+func setupRepoWithUserRoom(t *testing.T, repo string) (*gormRepository, *assert.Assertions, *require.Assertions, *User, *Room) {
 	t.Helper()
 	r, assert, require := setupRepo(t, repo)
 	room, user := mustMakeRoom(t, r, "here")
 	return r, assert, require, user, room
 }
 
-func setupRepoWithUserGroupRoomEvent(t *testing.T, repo string) (*GormRepository, *assert.Assertions, *require.Assertions, *User, *Group, *Room, *Event) {
+func setupRepoWithUserGroupRoomEvent(t *testing.T, repo string) (*gormRepository, *assert.Assertions, *require.Assertions, *User, *Group, *Room, *Event) {
 	t.Helper()
 	r, assert, require := setupRepo(t, repo)
 
@@ -148,7 +148,7 @@ func setupRepoWithUserGroupRoomEvent(t *testing.T, repo string) (*GormRepository
 	return r, assert, require, user, group, room, event
 }
 
-func mustMakeUser(t *testing.T, repo *GormRepository, privilege bool) *User {
+func mustMakeUser(t *testing.T, repo *gormRepository, privilege bool) *User {
 	t.Helper()
 	user := User{
 		Privilege: privilege,
@@ -166,7 +166,7 @@ func mustMakeUser(t *testing.T, repo *GormRepository, privilege bool) *User {
 // }
 
 // mustMakeGroup make group has no members
-func mustMakeGroup(t *testing.T, repo *GormRepository, name string) (*Group, *User) {
+func mustMakeGroup(t *testing.T, repo *gormRepository, name string) (*Group, *User) {
 	t.Helper()
 	user := mustMakeUser(t, repo, false)
 	params := WriteGroupParams{
@@ -190,7 +190,7 @@ func mustMakeGroup(t *testing.T, repo *GormRepository, name string) (*Group, *Us
 // }
 
 // mustMakeRoom make room. now -1h ~ now + 1h
-func mustMakeRoom(t *testing.T, repo *GormRepository, place string) (*Room, *User) {
+func mustMakeRoom(t *testing.T, repo *gormRepository, place string) (*Room, *User) {
 	t.Helper()
 
 	user := mustMakeUser(t, repo, false)
@@ -209,7 +209,7 @@ func mustMakeRoom(t *testing.T, repo *GormRepository, place string) (*Room, *Use
 }
 
 // mustMakeEvent make event. now ~ now + 1m
-func mustMakeEvent(t *testing.T, repo *GormRepository, name string) (*Event, *Group, *Room, *User) {
+func mustMakeEvent(t *testing.T, repo *gormRepository, name string) (*Event, *Group, *Room, *User) {
 	t.Helper()
 	group, user := mustMakeGroup(t, repo, random.AlphaNumeric(10, false))
 	room, _ := mustMakeRoom(t, repo, random.AlphaNumeric(10, false))

--- a/infra/db/event.go
+++ b/infra/db/event.go
@@ -27,42 +27,42 @@ type WriteEventParams struct {
 	CreatedBy uuid.UUID
 }
 
-func (repo *GormRepository) CreateEvent(params WriteEventParams) (*Event, error) {
+func (repo *gormRepository) CreateEvent(params WriteEventParams) (*Event, error) {
 	e, err := createEvent(repo.db, params)
 	return e, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) UpdateEvent(eventID uuid.UUID, params WriteEventParams) (*Event, error) {
+func (repo *gormRepository) UpdateEvent(eventID uuid.UUID, params WriteEventParams) (*Event, error) {
 	e, err := updateEvent(repo.db, eventID, params)
 	return e, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) AddEventTag(eventID uuid.UUID, params domain.EventTagParams) error {
+func (repo *gormRepository) AddEventTag(eventID uuid.UUID, params domain.EventTagParams) error {
 	err := addEventTag(repo.db, eventID, params)
 	return defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) DeleteEvent(eventID uuid.UUID) error {
+func (repo *gormRepository) DeleteEvent(eventID uuid.UUID) error {
 	err := deleteEvent(repo.db, eventID)
 	return defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) DeleteEventTag(eventID uuid.UUID, tagName string, deleteLocked bool) error {
+func (repo *gormRepository) DeleteEventTag(eventID uuid.UUID, tagName string, deleteLocked bool) error {
 	err := deleteEventTag(repo.db, eventID, tagName, deleteLocked)
 	return defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) UpsertEventSchedule(eventID, userID uuid.UUID, scheduleStatus domain.ScheduleStatus) error {
+func (repo *gormRepository) UpsertEventSchedule(eventID, userID uuid.UUID, scheduleStatus domain.ScheduleStatus) error {
 	err := upsertEventSchedule(repo.db, eventID, userID, scheduleStatus)
 	return defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) GetEvent(eventID uuid.UUID) (*Event, error) {
+func (repo *gormRepository) GetEvent(eventID uuid.UUID) (*Event, error) {
 	es, err := getEvent(eventFullPreload(repo.db), eventID)
 	return es, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) GetAllEvents(expr filters.Expr) ([]*Event, error) {
+func (repo *gormRepository) GetAllEvents(expr filters.Expr) ([]*Event, error) {
 	filterFormat, filterArgs, err := createEventFilter(expr)
 	if err != nil {
 		return nil, err

--- a/infra/db/group.go
+++ b/infra/db/group.go
@@ -20,37 +20,37 @@ type WriteGroupParams struct {
 	CreatedBy uuid.UUID
 }
 
-func (repo *GormRepository) CreateGroup(params WriteGroupParams) (*Group, error) {
+func (repo *gormRepository) CreateGroup(params WriteGroupParams) (*Group, error) {
 	g, err := createGroup(repo.db, params)
 	return g, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) UpdateGroup(groupID uuid.UUID, params WriteGroupParams) (*Group, error) {
+func (repo *gormRepository) UpdateGroup(groupID uuid.UUID, params WriteGroupParams) (*Group, error) {
 	g, err := updateGroup(repo.db, groupID, params)
 	return g, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) AddMemberToGroup(groupID, userID uuid.UUID) error {
+func (repo *gormRepository) AddMemberToGroup(groupID, userID uuid.UUID) error {
 	err := addMemberToGroup(repo.db, groupID, userID)
 	return defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) DeleteGroup(groupID uuid.UUID) error {
+func (repo *gormRepository) DeleteGroup(groupID uuid.UUID) error {
 	err := deleteGroup(repo.db, groupID)
 	return defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) DeleteMemberOfGroup(groupID, userID uuid.UUID) error {
+func (repo *gormRepository) DeleteMemberOfGroup(groupID, userID uuid.UUID) error {
 	err := deleteMemberOfGroup(repo.db, groupID, userID)
 	return defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) GetGroup(groupID uuid.UUID) (*Group, error) {
+func (repo *gormRepository) GetGroup(groupID uuid.UUID) (*Group, error) {
 	gs, err := getGroup(groupFullPreload(repo.db), groupID)
 	return gs, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) GetAllGroups() ([]*Group, error) {
+func (repo *gormRepository) GetAllGroups() ([]*Group, error) {
 	cmd := groupFullPreload(repo.db)
 	gs, err := getGroups(cmd.Joins(
 		"LEFT JOIN events ON groups.id = events.group_id "+
@@ -59,7 +59,7 @@ func (repo *GormRepository) GetAllGroups() ([]*Group, error) {
 	return gs, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) GetBelongGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *gormRepository) GetBelongGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
 	cmd := groupFullPreload(repo.db)
 	filterFormat, filterArgs, err := createGroupFilter(filters.FilterBelongs(userID))
 	if err != nil {
@@ -73,7 +73,7 @@ func (repo *GormRepository) GetBelongGroupIDs(userID uuid.UUID) ([]uuid.UUID, er
 	return convSPGroupToSuuidUUID(gs), defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) GetAdminGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *gormRepository) GetAdminGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
 	cmd := groupFullPreload(repo.db)
 	filterFormat, filterArgs, err := createGroupFilter(filters.FilterAdmins(userID))
 	if err != nil {

--- a/infra/db/room.go
+++ b/infra/db/room.go
@@ -31,7 +31,7 @@ type UpdateRoomParams struct {
 	CreatedBy uuid.UUID
 }
 
-func (repo GormRepository) CreateRoom(params CreateRoomParams) (*domain.Room, error) {
+func (repo gormRepository) CreateRoom(params CreateRoomParams) (*domain.Room, error) {
 	room, err := createRoom(repo.db, params)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -40,7 +40,7 @@ func (repo GormRepository) CreateRoom(params CreateRoomParams) (*domain.Room, er
 	return &r, nil
 }
 
-func (repo GormRepository) UpdateRoom(roomID uuid.UUID, params UpdateRoomParams) (*domain.Room, error) {
+func (repo gormRepository) UpdateRoom(roomID uuid.UUID, params UpdateRoomParams) (*domain.Room, error) {
 	room, err := updateRoom(repo.db, roomID, params)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -49,15 +49,15 @@ func (repo GormRepository) UpdateRoom(roomID uuid.UUID, params UpdateRoomParams)
 	return &r, nil
 }
 
-func (repo GormRepository) UpdateRoomVerified(roomID uuid.UUID, verified bool) error {
+func (repo gormRepository) UpdateRoomVerified(roomID uuid.UUID, verified bool) error {
 	return updateRoomVerified(repo.db, roomID, verified)
 }
 
-func (repo GormRepository) DeleteRoom(roomID uuid.UUID) error {
+func (repo gormRepository) DeleteRoom(roomID uuid.UUID) error {
 	return deleteRoom(repo.db, roomID)
 }
 
-func (repo GormRepository) GetRoom(roomID uuid.UUID, excludeEventID uuid.UUID) (*domain.Room, error) {
+func (repo gormRepository) GetRoom(roomID uuid.UUID, excludeEventID uuid.UUID) (*domain.Room, error) {
 	var room *Room
 	var err error
 	if excludeEventID == uuid.Nil {
@@ -72,7 +72,7 @@ func (repo GormRepository) GetRoom(roomID uuid.UUID, excludeEventID uuid.UUID) (
 	return &r, nil
 }
 
-func (repo GormRepository) GetAllRooms(start, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
+func (repo gormRepository) GetAllRooms(start, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
 	var rooms []*Room
 	var err error
 	if excludeEventID == uuid.Nil {

--- a/infra/db/tag.go
+++ b/infra/db/tag.go
@@ -6,7 +6,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func (repo *GormRepository) CreateOrGetTag(name string) (*domain.Tag, error) {
+func (repo *gormRepository) CreateOrGetTag(name string) (*domain.Tag, error) {
 	tag, err := createOrGetTag(repo.db, name)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -15,7 +15,7 @@ func (repo *GormRepository) CreateOrGetTag(name string) (*domain.Tag, error) {
 	return &t, nil
 }
 
-func (repo *GormRepository) GetTag(tagID uuid.UUID) (*domain.Tag, error) {
+func (repo *gormRepository) GetTag(tagID uuid.UUID) (*domain.Tag, error) {
 	tag, err := getTag(repo.db, tagID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -24,7 +24,7 @@ func (repo *GormRepository) GetTag(tagID uuid.UUID) (*domain.Tag, error) {
 	return &t, nil
 }
 
-func (repo *GormRepository) GetAllTags() ([]*domain.Tag, error) {
+func (repo *gormRepository) GetAllTags() ([]*domain.Tag, error) {
 	tags, err := getAllTags(repo.db)
 	if err != nil {
 		return nil, defaultErrorHandling(err)

--- a/infra/db/token.go
+++ b/infra/db/token.go
@@ -10,7 +10,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func (repo *GormRepository) GetToken(userID uuid.UUID) (*oauth2.Token, error) {
+func (repo *gormRepository) GetToken(userID uuid.UUID) (*oauth2.Token, error) {
 	return getToken(repo.db, userID)
 }
 

--- a/infra/db/user.go
+++ b/infra/db/user.go
@@ -11,27 +11,27 @@ func userPreload(tx *gorm.DB) *gorm.DB {
 	return tx.Preload("Provider")
 }
 
-func (repo *GormRepository) SaveUser(user User) (*User, error) {
+func (repo *gormRepository) SaveUser(user User) (*User, error) {
 	u, err := saveUser(repo.db, &user)
 	return u, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) UpdateiCalSecret(userID uuid.UUID, secret string) error {
+func (repo *gormRepository) UpdateiCalSecret(userID uuid.UUID, secret string) error {
 	err := updateiCalSecret(repo.db, userID, secret)
 	return defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) GetUser(userID uuid.UUID) (*User, error) {
+func (repo *gormRepository) GetUser(userID uuid.UUID) (*User, error) {
 	u, err := getUser(userPreload(repo.db), userID)
 	return u, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) GetAllUsers(onlyActive bool) ([]*User, error) {
+func (repo *gormRepository) GetAllUsers(onlyActive bool) ([]*User, error) {
 	us, err := getAllUsers(userPreload(repo.db), onlyActive)
 	return us, defaultErrorHandling(err)
 }
 
-func (repo *GormRepository) SyncUsers(users []*User) error {
+func (repo *gormRepository) SyncUsers(users []*User) error {
 	err := repo.db.Transaction(func(tx *gorm.DB) error {
 		existingUsers, err := getAllUsers(tx, false)
 		if err != nil {
@@ -110,7 +110,7 @@ func getAllUsers(db *gorm.DB, onlyActive bool) ([]*User, error) {
 	return users, err
 }
 
-func (repo *GormRepository) GrantPrivilege(userID uuid.UUID) error {
+func (repo *gormRepository) GrantPrivilege(userID uuid.UUID) error {
 	err := grantPrivilege(repo.db, userID)
 	return defaultErrorHandling(err)
 }

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	domain.REVISION = revision
 	domain.DEVELOPMENT, _ = strconv.ParseBool(development)
 
-	gormRepo := db.GormRepository{}
+	gormRepo := db.NewGormRepository()
 	err := gormRepo.Setup(mariadbHost, mariadbUser, mariadbPassword, mariadbDatabase, mariadbPort, tokenKey, gormLogLevel, tz.JST)
 	if err != nil {
 		panic(err)
@@ -99,7 +99,7 @@ func main() {
 	_, err = c.AddFunc(
 		"0 8 * * *",
 		utils.InitPostEventToTraQ(
-			&gormRepo,
+			gormRepo,
 			handler.WebhookSecret,
 			handler.DailyChannelID,
 			handler.WebhookID,

--- a/main.go
+++ b/main.go
@@ -73,10 +73,7 @@ func main() {
 		URL:               "https://q.trap.jp/api/v3",
 		ServerAccessToken: traqAccessToken,
 	}
-	repo := &repository.Repository{
-		GormRepo: gormRepo,
-		TraQRepo: traqRepo,
-	}
+	repo := repository.NewRepository(gormRepo, traqRepo)
 	handler := &router.Handlers{
 		Repo:       repo,
 		Logger:     logger,
@@ -102,7 +99,7 @@ func main() {
 	_, err = c.AddFunc(
 		"0 8 * * *",
 		utils.InitPostEventToTraQ(
-			&repo.GormRepo,
+			&gormRepo,
 			handler.WebhookSecret,
 			handler.DailyChannelID,
 			handler.WebhookID,

--- a/repository/event.go
+++ b/repository/event.go
@@ -8,7 +8,7 @@ import (
 	"github.com/traPtitech/knoQ/infra/db"
 )
 
-func (repo *Repository) CreateEvent(params domain.WriteEventParams, info *domain.ConInfo) (*domain.Event, error) {
+func (repo *repository) CreateEvent(params domain.WriteEventParams, info *domain.ConInfo) (*domain.Event, error) {
 	// groupの確認
 	group, err := repo.GetGroup(params.GroupID, info)
 	if err != nil {
@@ -29,7 +29,7 @@ func (repo *Repository) CreateEvent(params domain.WriteEventParams, info *domain
 	return repo.GetEvent(event.ID, info)
 }
 
-func (repo *Repository) UpdateEvent(eventID uuid.UUID, params domain.WriteEventParams, info *domain.ConInfo) (*domain.Event, error) {
+func (repo *repository) UpdateEvent(eventID uuid.UUID, params domain.WriteEventParams, info *domain.ConInfo) (*domain.Event, error) {
 	if !repo.IsEventAdmins(eventID, info) {
 		return nil, domain.ErrForbidden
 	}
@@ -68,7 +68,7 @@ func (repo *Repository) UpdateEvent(eventID uuid.UUID, params domain.WriteEventP
 	return repo.GetEvent(event.ID, info)
 }
 
-func (repo *Repository) AddEventTag(eventID uuid.UUID, tagName string, locked bool, info *domain.ConInfo) error {
+func (repo *repository) AddEventTag(eventID uuid.UUID, tagName string, locked bool, info *domain.ConInfo) error {
 	if locked && !repo.IsEventAdmins(eventID, info) {
 		return domain.ErrForbidden
 	}
@@ -77,7 +77,7 @@ func (repo *Repository) AddEventTag(eventID uuid.UUID, tagName string, locked bo
 	})
 }
 
-func (repo *Repository) DeleteEvent(eventID uuid.UUID, info *domain.ConInfo) error {
+func (repo *repository) DeleteEvent(eventID uuid.UUID, info *domain.ConInfo) error {
 	if !repo.IsEventAdmins(eventID, info) {
 		return domain.ErrForbidden
 	}
@@ -86,13 +86,13 @@ func (repo *Repository) DeleteEvent(eventID uuid.UUID, info *domain.ConInfo) err
 }
 
 // DeleteTagInEvent delete a tag in that Event
-func (repo *Repository) DeleteEventTag(eventID uuid.UUID, tagName string, info *domain.ConInfo) error {
+func (repo *repository) DeleteEventTag(eventID uuid.UUID, tagName string, info *domain.ConInfo) error {
 	deleteLocked := repo.IsEventAdmins(eventID, info)
 
 	return repo.GormRepo.DeleteEventTag(eventID, tagName, deleteLocked)
 }
 
-func (repo *Repository) GetEvent(eventID uuid.UUID, info *domain.ConInfo) (*domain.Event, error) {
+func (repo *repository) GetEvent(eventID uuid.UUID, info *domain.ConInfo) (*domain.Event, error) {
 	e, err := repo.GormRepo.GetEvent(eventID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -123,7 +123,7 @@ func (repo *Repository) GetEvent(eventID uuid.UUID, info *domain.ConInfo) (*doma
 	return &event, nil
 }
 
-func (repo *Repository) UpsertMeEventSchedule(eventID uuid.UUID, schedule domain.ScheduleStatus, info *domain.ConInfo) error {
+func (repo *repository) UpsertMeEventSchedule(eventID uuid.UUID, schedule domain.ScheduleStatus, info *domain.ConInfo) error {
 	event, err := repo.GetEvent(eventID, info)
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func (repo *Repository) UpsertMeEventSchedule(eventID uuid.UUID, schedule domain
 	return defaultErrorHandling(err)
 }
 
-func (repo *Repository) GetEvents(expr filters.Expr, info *domain.ConInfo) ([]*domain.Event, error) {
+func (repo *repository) GetEvents(expr filters.Expr, info *domain.ConInfo) ([]*domain.Event, error) {
 	expr = addTraQGroupIDs(repo, info.ReqUserID, expr)
 
 	es, err := repo.GormRepo.GetAllEvents(expr)
@@ -178,7 +178,7 @@ func (repo *Repository) GetEvents(expr filters.Expr, info *domain.ConInfo) ([]*d
 	return events, nil
 }
 
-func (repo *Repository) GetEventsWithGroup(expr filters.Expr, info *domain.ConInfo) ([]*domain.Event, error) {
+func (repo *repository) GetEventsWithGroup(expr filters.Expr, info *domain.ConInfo) ([]*domain.Event, error) {
 	expr = addTraQGroupIDs(repo, info.ReqUserID, expr)
 
 	es, err := repo.GormRepo.GetAllEvents(expr)
@@ -218,7 +218,7 @@ func (repo *Repository) GetEventsWithGroup(expr filters.Expr, info *domain.ConIn
 	return events, nil
 }
 
-func (repo *Repository) IsEventAdmins(eventID uuid.UUID, info *domain.ConInfo) bool {
+func (repo *repository) IsEventAdmins(eventID uuid.UUID, info *domain.ConInfo) bool {
 	event, err := repo.GormRepo.GetEvent(eventID)
 	if err != nil {
 		return false
@@ -248,7 +248,7 @@ func createUserMap(users []*domain.User) map[uuid.UUID]*domain.User {
 }
 
 // add traQ group and traP(111...)
-func addTraQGroupIDs(repo *Repository, userID uuid.UUID, expr filters.Expr) filters.Expr {
+func addTraQGroupIDs(repo *repository, userID uuid.UUID, expr filters.Expr) filters.Expr {
 	t, err := repo.GormRepo.GetToken(userID)
 	if err != nil {
 		return expr

--- a/repository/group.go
+++ b/repository/group.go
@@ -11,7 +11,7 @@ import (
 
 var traPGroupID = uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
 
-func (repo *Repository) CreateGroup(params domain.WriteGroupParams, info *domain.ConInfo) (*domain.Group, error) {
+func (repo *repository) CreateGroup(params domain.WriteGroupParams, info *domain.ConInfo) (*domain.Group, error) {
 	p := db.WriteGroupParams{
 		WriteGroupParams: params,
 		CreatedBy:        info.ReqUserID,
@@ -24,7 +24,7 @@ func (repo *Repository) CreateGroup(params domain.WriteGroupParams, info *domain
 	return &group, nil
 }
 
-func (repo *Repository) UpdateGroup(groupID uuid.UUID, params domain.WriteGroupParams, info *domain.ConInfo) (*domain.Group, error) {
+func (repo *repository) UpdateGroup(groupID uuid.UUID, params domain.WriteGroupParams, info *domain.ConInfo) (*domain.Group, error) {
 	if !repo.IsGroupAdmins(groupID, info) {
 		return nil, domain.ErrForbidden
 	}
@@ -41,14 +41,14 @@ func (repo *Repository) UpdateGroup(groupID uuid.UUID, params domain.WriteGroupP
 }
 
 // AddMeToGroup add me to that group if that group is open.
-func (repo *Repository) AddMeToGroup(groupID uuid.UUID, info *domain.ConInfo) error {
+func (repo *repository) AddMeToGroup(groupID uuid.UUID, info *domain.ConInfo) error {
 	if !repo.IsGroupJoinFreely(groupID) {
 		return domain.ErrForbidden
 	}
 	return repo.GormRepo.AddMemberToGroup(groupID, info.ReqUserID)
 }
 
-func (repo *Repository) DeleteGroup(groupID uuid.UUID, info *domain.ConInfo) error {
+func (repo *repository) DeleteGroup(groupID uuid.UUID, info *domain.ConInfo) error {
 	if !repo.IsGroupAdmins(groupID, info) {
 		return domain.ErrForbidden
 	}
@@ -56,14 +56,14 @@ func (repo *Repository) DeleteGroup(groupID uuid.UUID, info *domain.ConInfo) err
 }
 
 // DeleteMeGroup delete me in that group if that group is open.
-func (repo *Repository) DeleteMeGroup(groupID uuid.UUID, info *domain.ConInfo) error {
+func (repo *repository) DeleteMeGroup(groupID uuid.UUID, info *domain.ConInfo) error {
 	if !repo.IsGroupJoinFreely(groupID) {
 		return domain.ErrForbidden
 	}
 	return repo.GormRepo.DeleteMemberOfGroup(groupID, info.ReqUserID)
 }
 
-func (repo *Repository) GetGroup(groupID uuid.UUID, info *domain.ConInfo) (*domain.Group, error) {
+func (repo *repository) GetGroup(groupID uuid.UUID, info *domain.ConInfo) (*domain.Group, error) {
 	var group domain.Group
 	g, err := repo.GormRepo.GetGroup(groupID)
 	if err != nil {
@@ -89,7 +89,7 @@ func (repo *Repository) GetGroup(groupID uuid.UUID, info *domain.ConInfo) (*doma
 	return &group, nil
 }
 
-func (repo *Repository) GetAllGroups(info *domain.ConInfo) ([]*domain.Group, error) {
+func (repo *repository) GetAllGroups(info *domain.ConInfo) ([]*domain.Group, error) {
 	groups := make([]*domain.Group, 0)
 	gg, err := repo.GormRepo.GetAllGroups()
 	if err != nil {
@@ -111,7 +111,7 @@ func (repo *Repository) GetAllGroups(info *domain.ConInfo) ([]*domain.Group, err
 	return groups, nil
 }
 
-func (repo *Repository) GetUserBelongingGroupIDs(userID uuid.UUID, info *domain.ConInfo) ([]uuid.UUID, error) {
+func (repo *repository) GetUserBelongingGroupIDs(userID uuid.UUID, info *domain.ConInfo) ([]uuid.UUID, error) {
 	t, err := repo.GormRepo.GetToken(info.ReqUserID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -128,11 +128,11 @@ func (repo *Repository) GetUserBelongingGroupIDs(userID uuid.UUID, info *domain.
 	return append(append(ggIDs, traPGroupID), tgIDs...), nil
 }
 
-func (repo *Repository) GetUserAdminGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *repository) GetUserAdminGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
 	return repo.GormRepo.GetAdminGroupIDs(userID)
 }
 
-func (repo *Repository) IsGroupAdmins(groupID uuid.UUID, info *domain.ConInfo) bool {
+func (repo *repository) IsGroupAdmins(groupID uuid.UUID, info *domain.ConInfo) bool {
 	group, err := repo.GormRepo.GetGroup(groupID)
 	if err != nil {
 		return false
@@ -145,7 +145,7 @@ func (repo *Repository) IsGroupAdmins(groupID uuid.UUID, info *domain.ConInfo) b
 	return false
 }
 
-func (repo *Repository) IsGroupJoinFreely(groupID uuid.UUID) bool {
+func (repo *repository) IsGroupJoinFreely(groupID uuid.UUID) bool {
 	group, err := repo.GormRepo.GetGroup(groupID)
 	if err != nil {
 		return false
@@ -153,7 +153,7 @@ func (repo *Repository) IsGroupJoinFreely(groupID uuid.UUID) bool {
 	return group.JoinFreely
 }
 
-func (repo *Repository) IsGroupMember(userID, groupID uuid.UUID, info *domain.ConInfo) bool {
+func (repo *repository) IsGroupMember(userID, groupID uuid.UUID, info *domain.ConInfo) bool {
 	group, err := repo.GetGroup(groupID, info)
 	if err != nil {
 		return false
@@ -167,7 +167,7 @@ func (repo *Repository) IsGroupMember(userID, groupID uuid.UUID, info *domain.Co
 	return false
 }
 
-func (repo *Repository) getTraPGroup(info *domain.ConInfo) *domain.Group {
+func (repo *repository) getTraPGroup(info *domain.ConInfo) *domain.Group {
 	members, err := repo.GetAllUsers(false, false, info)
 	if err != nil {
 		return nil
@@ -186,7 +186,7 @@ func (repo *Repository) getTraPGroup(info *domain.ConInfo) *domain.Group {
 	}
 }
 
-func (repo *Repository) GetGradeGroupNames(_ *domain.ConInfo) ([]string, error) {
+func (repo *repository) GetGradeGroupNames(_ *domain.ConInfo) ([]string, error) {
 	groups, err := repo.TraQRepo.GetAllGroups()
 	if err != nil {
 		return nil, defaultErrorHandling(err)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -1,11 +1,26 @@
 package repository
 
 import (
+	"github.com/traPtitech/knoQ/domain"
 	"github.com/traPtitech/knoQ/infra/db"
 	"github.com/traPtitech/knoQ/infra/traq"
 )
 
-type Repository struct {
+// repository struct の実装を隠蔽する
+// あくまで domain.Repository の実装としてのみ存在させる
+type Repository interface {
+	domain.Repository
+}
+
+func NewRepository(gormRepo db.GormRepository, traQRepo traq.TraQRepository) Repository {
+	repo := repository{
+		GormRepo: gormRepo,
+		TraQRepo: traQRepo,
+	}
+	return repo
+}
+
+type repository struct {
 	GormRepo db.GormRepository
 	TraQRepo traq.TraQRepository
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -13,11 +13,10 @@ type Repository interface {
 }
 
 func NewRepository(gormRepo db.GormRepository, traQRepo traq.TraQRepository) Repository {
-	repo := repository{
+	return &repository{
 		GormRepo: gormRepo,
 		TraQRepo: traQRepo,
 	}
-	return repo
 }
 
 type repository struct {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -6,13 +6,8 @@ import (
 	"github.com/traPtitech/knoQ/infra/traq"
 )
 
-// repository struct の実装を隠蔽する
-// あくまで domain.Repository の実装としてのみ存在させる
-type Repository interface {
-	domain.Repository
-}
 
-func NewRepository(gormRepo db.GormRepository, traQRepo traq.TraQRepository) Repository {
+func NewRepository(gormRepo db.GormRepository, traQRepo traq.TraQRepository) domain.Repository {
 	return &repository{
 		GormRepo: gormRepo,
 		TraQRepo: traQRepo,

--- a/repository/room.go
+++ b/repository/room.go
@@ -8,7 +8,7 @@ import (
 	"github.com/traPtitech/knoQ/infra/db"
 )
 
-func (repo *Repository) CreateUnVerifiedRoom(params domain.WriteRoomParams, info *domain.ConInfo) (*domain.Room, error) {
+func (repo *repository) CreateUnVerifiedRoom(params domain.WriteRoomParams, info *domain.ConInfo) (*domain.Room, error) {
 	p := db.CreateRoomParams{
 		WriteRoomParams: params,
 		Verified:        false,
@@ -18,7 +18,7 @@ func (repo *Repository) CreateUnVerifiedRoom(params domain.WriteRoomParams, info
 	return r, defaultErrorHandling(err)
 }
 
-func (repo *Repository) CreateVerifiedRoom(params domain.WriteRoomParams, info *domain.ConInfo) (*domain.Room, error) {
+func (repo *repository) CreateVerifiedRoom(params domain.WriteRoomParams, info *domain.ConInfo) (*domain.Room, error) {
 	if !repo.IsPrivilege(info) {
 		return nil, domain.ErrForbidden
 	}
@@ -31,7 +31,7 @@ func (repo *Repository) CreateVerifiedRoom(params domain.WriteRoomParams, info *
 	return r, defaultErrorHandling(err)
 }
 
-func (repo *Repository) UpdateRoom(roomID uuid.UUID, params domain.WriteRoomParams, info *domain.ConInfo) (*domain.Room, error) {
+func (repo *repository) UpdateRoom(roomID uuid.UUID, params domain.WriteRoomParams, info *domain.ConInfo) (*domain.Room, error) {
 	if !repo.IsRoomAdmins(roomID, info) {
 		return nil, domain.ErrForbidden
 	}
@@ -45,7 +45,7 @@ func (repo *Repository) UpdateRoom(roomID uuid.UUID, params domain.WriteRoomPara
 	return r, defaultErrorHandling(err)
 }
 
-func (repo *Repository) VerifyRoom(roomID uuid.UUID, info *domain.ConInfo) error {
+func (repo *repository) VerifyRoom(roomID uuid.UUID, info *domain.ConInfo) error {
 	if !repo.IsPrivilege(info) {
 		return domain.ErrForbidden
 	}
@@ -53,7 +53,7 @@ func (repo *Repository) VerifyRoom(roomID uuid.UUID, info *domain.ConInfo) error
 	return defaultErrorHandling(err)
 }
 
-func (repo *Repository) UnVerifyRoom(roomID uuid.UUID, info *domain.ConInfo) error {
+func (repo *repository) UnVerifyRoom(roomID uuid.UUID, info *domain.ConInfo) error {
 	if !repo.IsPrivilege(info) {
 		return domain.ErrForbidden
 	}
@@ -61,7 +61,7 @@ func (repo *Repository) UnVerifyRoom(roomID uuid.UUID, info *domain.ConInfo) err
 	return defaultErrorHandling(err)
 }
 
-func (repo *Repository) DeleteRoom(roomID uuid.UUID, info *domain.ConInfo) error {
+func (repo *repository) DeleteRoom(roomID uuid.UUID, info *domain.ConInfo) error {
 	if !repo.IsRoomAdmins(roomID, info) {
 		return domain.ErrForbidden
 	}
@@ -69,17 +69,17 @@ func (repo *Repository) DeleteRoom(roomID uuid.UUID, info *domain.ConInfo) error
 	return defaultErrorHandling(err)
 }
 
-func (repo *Repository) GetRoom(roomID uuid.UUID, excludeEventID uuid.UUID) (*domain.Room, error) {
+func (repo *repository) GetRoom(roomID uuid.UUID, excludeEventID uuid.UUID) (*domain.Room, error) {
 	rs, err := repo.GormRepo.GetRoom(roomID, excludeEventID)
 	return rs, defaultErrorHandling(err)
 }
 
-func (repo *Repository) GetAllRooms(start time.Time, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
+func (repo *repository) GetAllRooms(start time.Time, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
 	rs, err := repo.GormRepo.GetAllRooms(start, end, excludeEventID)
 	return rs, defaultErrorHandling(err)
 }
 
-func (repo *Repository) IsRoomAdmins(roomID uuid.UUID, info *domain.ConInfo) bool {
+func (repo *repository) IsRoomAdmins(roomID uuid.UUID, info *domain.ConInfo) bool {
 	room, err := repo.GetRoom(roomID, uuid.Nil)
 	if err != nil {
 		return false

--- a/repository/tag.go
+++ b/repository/tag.go
@@ -5,17 +5,17 @@ import (
 	"github.com/traPtitech/knoQ/domain"
 )
 
-func (repo *Repository) CreateOrGetTag(name string) (*domain.Tag, error) {
+func (repo *repository) CreateOrGetTag(name string) (*domain.Tag, error) {
 	t, err := repo.GormRepo.CreateOrGetTag(name)
 	return t, defaultErrorHandling(err)
 }
 
-func (repo *Repository) GetTag(tagID uuid.UUID) (*domain.Tag, error) {
+func (repo *repository) GetTag(tagID uuid.UUID) (*domain.Tag, error) {
 	t, err := repo.GormRepo.GetTag(tagID)
 	return t, defaultErrorHandling(err)
 }
 
-func (repo *Repository) GetAllTags() ([]*domain.Tag, error) {
+func (repo *repository) GetAllTags() ([]*domain.Tag, error) {
 	ts, err := repo.GormRepo.GetAllTags()
 	return ts, defaultErrorHandling(err)
 }

--- a/repository/user.go
+++ b/repository/user.go
@@ -13,7 +13,7 @@ import (
 
 const traQIssuerName = "traQ"
 
-func (repo *Repository) SyncUsers(info *domain.ConInfo) error {
+func (repo *repository) SyncUsers(info *domain.ConInfo) error {
 	if !repo.IsPrivilege(info) {
 		return domain.ErrForbidden
 	}
@@ -45,11 +45,11 @@ func (repo *Repository) SyncUsers(info *domain.ConInfo) error {
 	return defaultErrorHandling(err)
 }
 
-func (repo *Repository) GetOAuthURL() (url, state, codeVerifier string) {
+func (repo *repository) GetOAuthURL() (url, state, codeVerifier string) {
 	return repo.TraQRepo.GetOAuthURL()
 }
 
-func (repo *Repository) LoginUser(query, state, codeVerifier string) (*domain.User, error) {
+func (repo *repository) LoginUser(query, state, codeVerifier string) (*domain.User, error) {
 	t, err := repo.TraQRepo.GetOAuthToken(query, state, codeVerifier)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -87,7 +87,7 @@ func (repo *Repository) LoginUser(query, state, codeVerifier string) (*domain.Us
 	return u, defaultErrorHandling(err)
 }
 
-func (repo *Repository) GetUser(userID uuid.UUID, _ *domain.ConInfo) (*domain.User, error) {
+func (repo *repository) GetUser(userID uuid.UUID, _ *domain.ConInfo) (*domain.User, error) {
 	userMeta, err := repo.GormRepo.GetUser(userID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -106,11 +106,11 @@ func (repo *Repository) GetUser(userID uuid.UUID, _ *domain.ConInfo) (*domain.Us
 	return nil, errors.New("not implemented")
 }
 
-func (repo *Repository) GetUserMe(info *domain.ConInfo) (*domain.User, error) {
+func (repo *repository) GetUserMe(info *domain.ConInfo) (*domain.User, error) {
 	return repo.GetUser(info.ReqUserID, info)
 }
 
-func (repo *Repository) GetAllUsers(includeSuspend, includeBot bool, _ *domain.ConInfo) ([]*domain.User, error) {
+func (repo *repository) GetAllUsers(includeSuspend, includeBot bool, _ *domain.ConInfo) ([]*domain.User, error) {
 	userMetas, err := repo.GormRepo.GetAllUsers(!includeSuspend)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -140,13 +140,13 @@ func (repo *Repository) GetAllUsers(includeSuspend, includeBot bool, _ *domain.C
 	return users, nil
 }
 
-func (repo *Repository) ReNewMyiCalSecret(info *domain.ConInfo) (secret string, err error) {
+func (repo *repository) ReNewMyiCalSecret(info *domain.ConInfo) (secret string, err error) {
 	secret = random.AlphaNumeric(16, true)
 	err = repo.GormRepo.UpdateiCalSecret(info.ReqUserID, secret)
 	return
 }
 
-func (repo *Repository) GetMyiCalSecret(info *domain.ConInfo) (string, error) {
+func (repo *repository) GetMyiCalSecret(info *domain.ConInfo) (string, error) {
 	user, err := repo.GormRepo.GetUser(info.ReqUserID)
 	if err != nil {
 		return "", defaultErrorHandling(err)
@@ -160,7 +160,7 @@ func (repo *Repository) GetMyiCalSecret(info *domain.ConInfo) (string, error) {
 	return user.IcalSecret, nil
 }
 
-func (repo *Repository) IsPrivilege(info *domain.ConInfo) bool {
+func (repo *repository) IsPrivilege(info *domain.ConInfo) bool {
 	user, err := repo.GormRepo.GetUser(info.ReqUserID)
 	if err != nil {
 		return false
@@ -177,7 +177,7 @@ func traQUserMap(users []traq.User) map[uuid.UUID]*traq.User {
 	return userMap
 }
 
-func (repo *Repository) mergeUser(userMeta *db.User, userBody *traq.User) (*domain.User, error) {
+func (repo *repository) mergeUser(userMeta *db.User, userBody *traq.User) (*domain.User, error) {
 	if userMeta.ID != uuid.Must(uuid.FromString(userBody.GetId())) {
 		return nil, errors.New("id does not match")
 	}
@@ -194,7 +194,7 @@ func (repo *Repository) mergeUser(userMeta *db.User, userBody *traq.User) (*doma
 	}, nil
 }
 
-func (repo *Repository) GrantPrivilege(userID uuid.UUID) error {
+func (repo *repository) GrantPrivilege(userID uuid.UUID) error {
 	user, err := repo.GormRepo.GetUser(userID)
 	if err != nil {
 		return defaultErrorHandling(err)

--- a/utils/cron.go
+++ b/utils/cron.go
@@ -21,7 +21,7 @@ type timeTable struct {
 
 // InitPostEventToTraQ 現在(job実行)から24時間以内に始まるイベントを取得し、
 // webhookでtraQに送るjobを作成。
-func InitPostEventToTraQ(repo *db.GormRepository, secret, channelID, webhookID, origin string) func() {
+func InitPostEventToTraQ(repo db.GormRepository, secret, channelID, webhookID, origin string) func() {
 	job := func() {
 		now := setTimeFromString(time.Now().In(tz.JST), "06:00:00")
 		tomorrow := now.AddDate(0, 0, 1)


### PR DESCRIPTION
db.GormRepository と repository.Repository を interface化しました。
それに伴い、構造体を使用していたmain.go,cron.goにinterfaceを使用するように変更を加えました。