### PR TITLE
fix: Update go-traq

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.51.0
 	github.com/stretchr/testify v1.11.1
-	github.com/traPtitech/go-traq v0.0.0-20240725071454-97c7b85dc879
+	github.com/traPtitech/go-traq v0.0.0-20251201015624-285ca186fc5e
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/oauth2 v0.31.0
@@ -86,6 +86,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250929231259-57b25ae835d4 // indirect
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/validator.v2 v2.0.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/traPtitech/go-traq v0.0.0-20240725071454-97c7b85dc879 h1:kkMhrXZXa7aP57ay31a3AydSPcDU1K73vXRYrSPs+P8=
-github.com/traPtitech/go-traq v0.0.0-20240725071454-97c7b85dc879/go.mod h1:7yJs1m/ddCG39XF78GA8FrXqyc4fNPfHp8BSLjMVMY8=
+github.com/traPtitech/go-traq v0.0.0-20251201015624-285ca186fc5e h1:CPWnxqmdaYKFIw/OtXQeucdkmqgB+3HTNQw2Tu1IImQ=
+github.com/traPtitech/go-traq v0.0.0-20251201015624-285ca186fc5e/go.mod h1:D7NRbLYlvMey05bV+3Yqea6+Onj0ACmMgLuvP7+far8=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
@@ -225,6 +225,8 @@ google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXn
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
+gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/infra/traq/group.go
+++ b/infra/traq/group.go
@@ -13,7 +13,7 @@ func (repo *TraQRepository) GetGroup(groupID uuid.UUID) (*traq.UserGroup, error)
 	ctx := context.WithValue(context.TODO(), traq.ContextAccessToken, repo.ServerAccessToken)
 	apiClient := traq.NewAPIClient(traq.NewConfiguration())
 	// TODO: 一定期間キャッシュする
-	group, resp, err := apiClient.GroupApi.GetUserGroup(ctx, groupID.String()).Execute()
+	group, resp, err := apiClient.GroupAPI.GetUserGroup(ctx, groupID.String()).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func (repo *TraQRepository) GetAllGroups() ([]traq.UserGroup, error) {
 	ctx := context.WithValue(context.TODO(), traq.ContextAccessToken, repo.ServerAccessToken)
 	apiClient := traq.NewAPIClient(traq.NewConfiguration())
 	// TODO: 一定期間キャッシュする
-	groups, resp, err := apiClient.GroupApi.GetUserGroups(ctx).Execute()
+	groups, resp, err := apiClient.GroupAPI.GetUserGroups(ctx).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func (repo *TraQRepository) GetAllGroups() ([]traq.UserGroup, error) {
 func (repo *TraQRepository) GetUserBelongingGroupIDs(token *oauth2.Token, userID uuid.UUID) ([]uuid.UUID, error) {
 	ctx := context.WithValue(context.TODO(), traq.ContextAccessToken, token.AccessToken)
 	apiClient := traq.NewAPIClient(traq.NewConfiguration())
-	user, resp, err := apiClient.UserApi.GetUser(ctx, userID.String()).Execute()
+	user, resp, err := apiClient.UserAPI.GetUser(ctx, userID.String()).Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/infra/traq/user.go
+++ b/infra/traq/user.go
@@ -12,7 +12,7 @@ func (repo *TraQRepository) GetUser(userID uuid.UUID) (*traq.User, error) {
 	ctx := context.WithValue(context.TODO(), traq.ContextAccessToken, repo.ServerAccessToken)
 	apiClient := traq.NewAPIClient(traq.NewConfiguration())
 	// TODO: 一定期間キャッシュする
-	userDetail, resp, err := apiClient.UserApi.GetUser(ctx, userID.String()).Execute()
+	userDetail, resp, err := apiClient.UserAPI.GetUser(ctx, userID.String()).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (repo *TraQRepository) GetUsers(includeSuspended bool) ([]traq.User, error)
 	ctx := context.WithValue(context.TODO(), traq.ContextAccessToken, repo.ServerAccessToken)
 	apiClient := traq.NewAPIClient(traq.NewConfiguration())
 	// TODO: 一定期間キャッシュする
-	users, resp, err := apiClient.UserApi.GetUsers(ctx).IncludeSuspended(includeSuspended).Execute()
+	users, resp, err := apiClient.UserAPI.GetUsers(ctx).IncludeSuspended(includeSuspended).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (repo *TraQRepository) GetUsers(includeSuspended bool) ([]traq.User, error)
 func (repo *TraQRepository) GetUserMe(token *oauth2.Token) (*traq.User, error) {
 	ctx := context.WithValue(context.TODO(), traq.ContextAccessToken, token.AccessToken)
 	apiClient := traq.NewAPIClient(traq.NewConfiguration())
-	userDetail, resp, err := apiClient.MeApi.GetMe(ctx).Execute()
+	userDetail, resp, err := apiClient.MeAPI.GetMe(ctx).Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/utils/api.go
+++ b/utils/api.go
@@ -17,7 +17,7 @@ func RequestWebhook(message, secret, channelID, webhookID string, embed int) err
 	apiClient := traq.NewAPIClient(configuration)
 
 	xTRAQSignature := calcSignature(message, secret)
-	res, err := apiClient.WebhookApi.PostWebhook(context.TODO(), webhookID).
+	res, err := apiClient.WebhookAPI.PostWebhook(context.TODO(), webhookID).
 		XTRAQChannelId(channelID).XTRAQSignature(xTRAQSignature).
 		Embed(int32(embed)).Body(message).Execute()
 	if err != nil {


### PR DESCRIPTION
traQのバージョンアップにより古いgo-traqにエラーが発生したのでバージョンアップします。
https://github.com/traPtitech/go-traq/commit/285ca186fc5e4ef65afb8f4325ff9efcac64b32f

openapi-generatorのバージョンアップにより `APIClient.~~Api` が全て`APIClient.~~API` と大文字に変更されています。

