### PR TITLE
feat: リリース時にmanifest-renovateを回す

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -42,3 +42,17 @@ jobs:
           tags: |
             ghcr.io/traptitech/${{ env.IMAGE_NAME }}:latest
             ghcr.io/traptitech/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+  run-manifest-renovate:
+    name: Run Renovate on manifest
+    runs-on: ubuntu-latest
+    needs: [image]
+
+    permissions:
+      contents: read
+      actions: write
+
+    steps:
+      - run: 'gh api --method POST -H "Accept: application/vnd.github+json" /repos/traPtitech/manifest/actions/workflows/renovate.yaml/dispatches -f "ref=main"'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -40,15 +40,16 @@ jobs:
           tags: |
             ghcr.io/traptitech/${{ env.IMAGE_NAME }}:main
 
-  deploy-staging:
-    name: Deploy staging
+  run-manifest-renovate:
+    name: Run Renovate on manifest
     runs-on: ubuntu-latest
     needs: [image]
+
+    permissions:
+      contents: read
+      actions: write
+
     steps:
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.STAGING_SSH_KEY }}
-          known_hosts: ${{ secrets.STAGING_KNOWN_HOSTS }}
-      - name: Deploy
-        run: ssh -t ${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }} "sudo sh /srv/knoq/deploy.sh server"
+      - run: 'gh api --method POST -H "Accept: application/vnd.github+json" /repos/traPtitech/manifest/actions/workflows/renovate.yaml/dispatches -f "ref=main"'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/traPtitech/knoQ
 
-go 1.24.1
+go 1.25.0
 
 require (
 	github.com/arran4/golang-ical v0.3.2


### PR DESCRIPTION
 リリース時にmanifestのRenovateを動かすようにGHAを書き変えた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDパイプラインにRenovateワークフロー自動化を統合し、依存関係管理を効率化
  * Goツールチェーンをバージョン1.25.0に更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->