### PR TITLE
Service層でtransactionを張る

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"time"
 )
 
@@ -14,6 +15,10 @@ type Model struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt *time.Time
+}
+
+type TransactionManager interface {
+	Do(ctx context.Context, fn func(ctx context.Context) error) error
 }
 
 type Service interface {

--- a/domain/event.go
+++ b/domain/event.go
@@ -117,19 +117,19 @@ type UpsertEventArgs struct {
 }
 
 type EventRepository interface {
-	CreateEvent(args UpsertEventArgs) (*Event, error)
+	CreateEvent(ctx context.Context, args UpsertEventArgs) (*Event, error)
 
-	UpdateEvent(eventID uuid.UUID, args UpsertEventArgs) (*Event, error)
+	UpdateEvent(ctx context.Context, eventID uuid.UUID, args UpsertEventArgs) (*Event, error)
 
-	AddEventTag(eventID uuid.UUID, params EventTagParams) error
+	AddEventTag(ctx context.Context, eventID uuid.UUID, params EventTagParams) error
 
-	DeleteEvent(eventID uuid.UUID) error
+	DeleteEvent(ctx context.Context, eventID uuid.UUID) error
 
-	DeleteEventTag(eventID uuid.UUID, tagName string, deleteLocked bool) error
+	DeleteEventTag(ctx context.Context, eventID uuid.UUID, tagName string, deleteLocked bool) error
 
-	UpsertEventSchedule(eventID, userID uuid.UUID, scheduleStatus ScheduleStatus) error
+	UpsertEventSchedule(ctx context.Context, eventID, userID uuid.UUID, scheduleStatus ScheduleStatus) error
 
-	GetEvent(eventID uuid.UUID) (*Event, error)
+	GetEvent(ctx context.Context, eventID uuid.UUID) (*Event, error)
 
-	GetAllEvents(expr filters.Expr) ([]*Event, error)
+	GetAllEvents(ctx context.Context, expr filters.Expr) ([]*Event, error)
 }

--- a/domain/group.go
+++ b/domain/group.go
@@ -53,21 +53,21 @@ type UpsertGroupArgs struct {
 }
 
 type GroupRepository interface {
-	CreateGroup(args UpsertGroupArgs) (*Group, error)
+	CreateGroup(ctx context.Context, args UpsertGroupArgs) (*Group, error)
 
-	UpdateGroup(groupID uuid.UUID, args UpsertGroupArgs) (*Group, error)
+	UpdateGroup(ctx context.Context, groupID uuid.UUID, args UpsertGroupArgs) (*Group, error)
 
-	AddMemberToGroup(groupID, userID uuid.UUID) error
+	AddMemberToGroup(ctx context.Context, groupID, userID uuid.UUID) error
 
-	DeleteGroup(groupID uuid.UUID) error
+	DeleteGroup(ctx context.Context, groupID uuid.UUID) error
 
-	DeleteMemberOfGroup(groupID, userID uuid.UUID) error
+	DeleteMemberOfGroup(ctx context.Context, groupID, userID uuid.UUID) error
 
-	GetGroup(groupID uuid.UUID) (*Group, error)
+	GetGroup(ctx context.Context, groupID uuid.UUID) (*Group, error)
 
-	GetAllGroups() ([]*Group, error)
+	GetAllGroups(ctx context.Context) ([]*Group, error)
 
-	GetBelongGroupIDs(userID uuid.UUID) ([]uuid.UUID, error)
+	GetBelongGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error)
 
-	GetAdminGroupIDs(userID uuid.UUID) ([]uuid.UUID, error)
+	GetAdminGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error)
 }

--- a/domain/room.go
+++ b/domain/room.go
@@ -184,15 +184,15 @@ type UpdateRoomArgs struct {
 }
 
 type RoomRepository interface {
-	CreateRoom(args CreateRoomArgs) (*Room, error)
+	CreateRoom(ctx context.Context, args CreateRoomArgs) (*Room, error)
 
-	UpdateRoom(roomID uuid.UUID, args UpdateRoomArgs) (*Room, error)
+	UpdateRoom(ctx context.Context, roomID uuid.UUID, args UpdateRoomArgs) (*Room, error)
 
-	UpdateRoomVerified(roomID uuid.UUID, verified bool) error
+	UpdateRoomVerified(ctx context.Context, roomID uuid.UUID, verified bool) error
 
-	DeleteRoom(roomID uuid.UUID) error
+	DeleteRoom(ctx context.Context, roomID uuid.UUID) error
 
-	GetRoom(roomID uuid.UUID, excludeEventID uuid.UUID) (*Room, error)
+	GetRoom(ctx context.Context, roomID uuid.UUID, excludeEventID uuid.UUID) (*Room, error)
 
-	GetAllRooms(start, end time.Time, excludeEventID uuid.UUID) ([]*Room, error)
+	GetAllRooms(ctx context.Context, start, end time.Time, excludeEventID uuid.UUID) ([]*Room, error)
 }

--- a/domain/tag.go
+++ b/domain/tag.go
@@ -19,7 +19,7 @@ type TagService interface {
 }
 
 type TagRepository interface {
-	CreateOrGetTag(name string) (*Tag, error)
-	GetTag(tagID uuid.UUID) (*Tag, error)
-	GetAllTags() ([]*Tag, error)
+	CreateOrGetTag(ctx context.Context, name string) (*Tag, error)
+	GetTag(ctx context.Context, tagID uuid.UUID) (*Tag, error)
+	GetAllTags(ctx context.Context) ([]*Tag, error)
 }

--- a/domain/user.go
+++ b/domain/user.go
@@ -68,12 +68,12 @@ type SyncUserArgs struct {
 }
 
 type UserRepository interface {
-	SaveUser(args SaveUserArgs) (*User, error)
-	UpdateiCalSecret(userID uuid.UUID, secret string) error
-	GetUser(userID uuid.UUID) (*User, error)
-	GetAllUsers(onlyActive bool) ([]*User, error)
-	SyncUsers(args []SyncUserArgs) error
-	GrantPrivilege(userID uuid.UUID) error
-	GetICalSecret(userID uuid.UUID) (string, error)
-	GetToken(userID uuid.UUID) (*oauth2.Token, error)
+	SaveUser(ctx context.Context, args SaveUserArgs) (*User, error)
+	UpdateiCalSecret(ctx context.Context, userID uuid.UUID, secret string) error
+	GetUser(ctx context.Context, userID uuid.UUID) (*User, error)
+	GetAllUsers(ctx context.Context, onlyActive bool) ([]*User, error)
+	SyncUsers(ctx context.Context, args []SyncUserArgs) error
+	GrantPrivilege(ctx context.Context, userID uuid.UUID) error
+	GetICalSecret(ctx context.Context, userID uuid.UUID) (string, error)
+	GetToken(ctx context.Context, userID uuid.UUID) (*oauth2.Token, error)
 }

--- a/infra/db/db.go
+++ b/infra/db/db.go
@@ -67,8 +67,9 @@ func (repo *gormRepository) Setup(host, user, password, database, port, key, log
 	return migration.Migrate(repo.db, tables)
 }
 
-func NewRepository(host, user, password, database, port, key, logLevel string, loc *time.Location) (domain.Repository, error) {
+func NewRepository(host, user, password, database, port, key, logLevel string, loc *time.Location) (domain.Repository, domain.TransactionManager , error) {
 	r := gormRepository{}
 	err := r.Setup(host, user, password, database, port, key, logLevel, loc)
-	return &r, err
+	tx := NewTransactionManager(r.db)
+	return &r, tx , err
 }

--- a/infra/db/event.go
+++ b/infra/db/event.go
@@ -23,7 +23,7 @@ func eventFullPreload(tx *gorm.DB) *gorm.DB {
 }
 
 func (repo *gormRepository) CreateEvent(ctx context.Context, args domain.UpsertEventArgs) (*domain.Event, error) {
-	e, err := createEvent(getTx(ctx, repo.db), args)
+	e, err := createEvent(getTx(ctx, repo.db.WithContext(ctx)), args)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -32,7 +32,7 @@ func (repo *gormRepository) CreateEvent(ctx context.Context, args domain.UpsertE
 }
 
 func (repo *gormRepository) UpdateEvent(ctx context.Context, eventID uuid.UUID, args domain.UpsertEventArgs) (*domain.Event, error) {
-	e, err := updateEvent(getTx(ctx, repo.db), eventID, args)
+	e, err := updateEvent(getTx(ctx, repo.db.WithContext(ctx)), eventID, args)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -41,27 +41,27 @@ func (repo *gormRepository) UpdateEvent(ctx context.Context, eventID uuid.UUID, 
 }
 
 func (repo *gormRepository) AddEventTag(ctx context.Context, eventID uuid.UUID, params domain.EventTagParams) error {
-	err := addEventTag(getTx(ctx, repo.db), eventID, params)
+	err := addEventTag(getTx(ctx, repo.db.WithContext(ctx)), eventID, params)
 	return defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) DeleteEvent(ctx context.Context, eventID uuid.UUID) error {
-	err := deleteEvent(getTx(ctx, repo.db), eventID)
+	err := deleteEvent(getTx(ctx, repo.db.WithContext(ctx)), eventID)
 	return defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) DeleteEventTag(ctx context.Context, eventID uuid.UUID, tagName string, deleteLocked bool) error {
-	err := deleteEventTag(getTx(ctx, repo.db), eventID, tagName, deleteLocked)
+	err := deleteEventTag(getTx(ctx, repo.db.WithContext(ctx)), eventID, tagName, deleteLocked)
 	return defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) UpsertEventSchedule(ctx context.Context, eventID, userID uuid.UUID, scheduleStatus domain.ScheduleStatus) error {
-	err := upsertEventSchedule(getTx(ctx, repo.db), eventID, userID, scheduleStatus)
+	err := upsertEventSchedule(getTx(ctx, repo.db.WithContext(ctx)), eventID, userID, scheduleStatus)
 	return defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) GetEvent(ctx context.Context, eventID uuid.UUID) (*domain.Event, error) {
-	e, err := getEvent(eventFullPreload(getTx(ctx, repo.db)), eventID)
+	e, err := getEvent(eventFullPreload(getTx(ctx, repo.db.WithContext(ctx))), eventID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -74,7 +74,7 @@ func (repo *gormRepository) GetAllEvents(ctx context.Context, expr filters.Expr)
 	if err != nil {
 		return nil, err
 	}
-	tx := getTx(ctx,repo.db)
+	tx := getTx(ctx, repo.db.WithContext(ctx))
 	cmd := eventFullPreload(tx)
 	es, err := getEvents(cmd.Joins(
 		"LEFT JOIN event_tags ON events.id = event_tags.event_id "+

--- a/infra/db/event.go
+++ b/infra/db/event.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -21,50 +22,60 @@ func eventFullPreload(tx *gorm.DB) *gorm.DB {
 		Preload("CreatedBy")
 }
 
-func (repo *gormRepository) CreateEvent(args domain.UpsertEventArgs) (*domain.Event, error) {
-	e, err := createEvent(repo.db, args)
+func (repo *gormRepository) CreateEvent(ctx context.Context, args domain.UpsertEventArgs) (*domain.Event, error) {
+	e, err := createEvent(getTx(ctx, repo.db), args)
+	if err != nil {
+		return nil, defaultErrorHandling(err)
+	}
 	de := convEventTodomainEvent(*e)
 	return &de, defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) UpdateEvent(eventID uuid.UUID, args domain.UpsertEventArgs) (*domain.Event, error) {
-	e, err := updateEvent(repo.db, eventID, args)
+func (repo *gormRepository) UpdateEvent(ctx context.Context, eventID uuid.UUID, args domain.UpsertEventArgs) (*domain.Event, error) {
+	e, err := updateEvent(getTx(ctx, repo.db), eventID, args)
+	if err != nil {
+		return nil, defaultErrorHandling(err)
+	}
 	de := convEventTodomainEvent(*e)
 	return &de, defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) AddEventTag(eventID uuid.UUID, params domain.EventTagParams) error {
-	err := addEventTag(repo.db, eventID, params)
+func (repo *gormRepository) AddEventTag(ctx context.Context, eventID uuid.UUID, params domain.EventTagParams) error {
+	err := addEventTag(getTx(ctx, repo.db), eventID, params)
 	return defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) DeleteEvent(eventID uuid.UUID) error {
-	err := deleteEvent(repo.db, eventID)
+func (repo *gormRepository) DeleteEvent(ctx context.Context, eventID uuid.UUID) error {
+	err := deleteEvent(getTx(ctx, repo.db), eventID)
 	return defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) DeleteEventTag(eventID uuid.UUID, tagName string, deleteLocked bool) error {
-	err := deleteEventTag(repo.db, eventID, tagName, deleteLocked)
+func (repo *gormRepository) DeleteEventTag(ctx context.Context, eventID uuid.UUID, tagName string, deleteLocked bool) error {
+	err := deleteEventTag(getTx(ctx, repo.db), eventID, tagName, deleteLocked)
 	return defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) UpsertEventSchedule(eventID, userID uuid.UUID, scheduleStatus domain.ScheduleStatus) error {
-	err := upsertEventSchedule(repo.db, eventID, userID, scheduleStatus)
+func (repo *gormRepository) UpsertEventSchedule(ctx context.Context, eventID, userID uuid.UUID, scheduleStatus domain.ScheduleStatus) error {
+	err := upsertEventSchedule(getTx(ctx, repo.db), eventID, userID, scheduleStatus)
 	return defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) GetEvent(eventID uuid.UUID) (*domain.Event, error) {
-	e, err := getEvent(eventFullPreload(repo.db), eventID)
+func (repo *gormRepository) GetEvent(ctx context.Context, eventID uuid.UUID) (*domain.Event, error) {
+	e, err := getEvent(eventFullPreload(getTx(ctx, repo.db)), eventID)
+	if err != nil {
+		return nil, defaultErrorHandling(err)
+	}
 	de := convEventTodomainEvent(*e)
 	return &de, defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) GetAllEvents(expr filters.Expr) ([]*domain.Event, error) {
+func (repo *gormRepository) GetAllEvents(ctx context.Context, expr filters.Expr) ([]*domain.Event, error) {
 	filterFormat, filterArgs, err := createEventFilter(expr)
 	if err != nil {
 		return nil, err
 	}
-	cmd := eventFullPreload(repo.db)
+	tx := getTx(ctx,repo.db)
+	cmd := eventFullPreload(tx)
 	es, err := getEvents(cmd.Joins(
 		"LEFT JOIN event_tags ON events.id = event_tags.event_id "+
 			"LEFT JOIN group_members ON events.group_id = group_members.group_id "+

--- a/infra/db/group.go
+++ b/infra/db/group.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gofrs/uuid"
@@ -14,41 +15,47 @@ func groupFullPreload(tx *gorm.DB) *gorm.DB {
 	return tx.Preload("Members").Preload("Admins").Preload("CreatedBy")
 }
 
-func (repo *gormRepository) CreateGroup(args domain.UpsertGroupArgs) (*domain.Group, error) {
-	g, err := createGroup(repo.db, args)
+func (repo *gormRepository) CreateGroup(ctx context.Context, args domain.UpsertGroupArgs) (*domain.Group, error) {
+	g, err := createGroup(getTx(ctx, repo.db), args)
+	if err != nil {
+		return nil, defaultErrorHandling(err)
+	}
 	domainGroup := convGroupTodomainGroup(*g)
 	return &domainGroup, defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) UpdateGroup(groupID uuid.UUID, args domain.UpsertGroupArgs) (*domain.Group, error) {
-	g, err := updateGroup(repo.db, groupID, args)
+func (repo *gormRepository) UpdateGroup(ctx context.Context, groupID uuid.UUID, args domain.UpsertGroupArgs) (*domain.Group, error) {
+	g, err := updateGroup(getTx(ctx, repo.db), groupID, args)
+	if err != nil {
+		return nil, defaultErrorHandling(err)
+	}
 	domainGroup := convGroupTodomainGroup(*g)
 	return &domainGroup, defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) AddMemberToGroup(groupID, userID uuid.UUID) error {
-	err := addMemberToGroup(repo.db, groupID, userID)
+func (repo *gormRepository) AddMemberToGroup(ctx context.Context, groupID, userID uuid.UUID) error {
+	err := addMemberToGroup(getTx(ctx, repo.db), groupID, userID)
 	return defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) DeleteGroup(groupID uuid.UUID) error {
-	err := deleteGroup(repo.db, groupID)
+func (repo *gormRepository) DeleteGroup(ctx context.Context, groupID uuid.UUID) error {
+	err := deleteGroup(getTx(ctx, repo.db), groupID)
 	return defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) DeleteMemberOfGroup(groupID, userID uuid.UUID) error {
-	err := deleteMemberOfGroup(repo.db, groupID, userID)
+func (repo *gormRepository) DeleteMemberOfGroup(ctx context.Context, groupID, userID uuid.UUID) error {
+	err := deleteMemberOfGroup(getTx(ctx, repo.db), groupID, userID)
 	return defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) GetGroup(groupID uuid.UUID) (*domain.Group, error) {
-	g, err := getGroup(groupFullPreload(repo.db), groupID)
+func (repo *gormRepository) GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.Group, error) {
+	g, err := getGroup(groupFullPreload(getTx(ctx, repo.db)), groupID)
 	domainGroup := convGroupTodomainGroup(*g)
 	return &domainGroup, defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) GetAllGroups() ([]*domain.Group, error) {
-	cmd := groupFullPreload(repo.db)
+func (repo *gormRepository) GetAllGroups(ctx context.Context) ([]*domain.Group, error) {
+	cmd := groupFullPreload(getTx(ctx, repo.db))
 	gs, err := getGroups(cmd.Joins(
 		"LEFT JOIN events ON groups.id = events.group_id "+
 			"LEFT JOIN group_members ON groups.id = group_members.group_id "+
@@ -57,8 +64,8 @@ func (repo *gormRepository) GetAllGroups() ([]*domain.Group, error) {
 	return ConvSPGroupToSPdomainGroup(gs), defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) GetBelongGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
-	cmd := groupFullPreload(repo.db)
+func (repo *gormRepository) GetBelongGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
+	cmd := groupFullPreload(getTx(ctx, repo.db))
 	filterFormat, filterArgs, err := createGroupFilter(filters.FilterBelongs(userID))
 	if err != nil {
 		return nil, err
@@ -71,8 +78,8 @@ func (repo *gormRepository) GetBelongGroupIDs(userID uuid.UUID) ([]uuid.UUID, er
 	return convSPGroupToSuuidUUID(gs), defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) GetAdminGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
-	cmd := groupFullPreload(repo.db)
+func (repo *gormRepository) GetAdminGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
+	cmd := groupFullPreload(getTx(ctx, repo.db))
 	filterFormat, filterArgs, err := createGroupFilter(filters.FilterAdmins(userID))
 	if err != nil {
 		return nil, err
@@ -177,7 +184,7 @@ func updateGroup(db *gorm.DB, groupID uuid.UUID, args domain.UpsertGroupArgs) (*
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return &group, err
 }
 

--- a/infra/db/group.go
+++ b/infra/db/group.go
@@ -16,7 +16,7 @@ func groupFullPreload(tx *gorm.DB) *gorm.DB {
 }
 
 func (repo *gormRepository) CreateGroup(ctx context.Context, args domain.UpsertGroupArgs) (*domain.Group, error) {
-	g, err := createGroup(getTx(ctx, repo.db), args)
+	g, err := createGroup(getTx(ctx, repo.db.WithContext(ctx)), args)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -25,7 +25,7 @@ func (repo *gormRepository) CreateGroup(ctx context.Context, args domain.UpsertG
 }
 
 func (repo *gormRepository) UpdateGroup(ctx context.Context, groupID uuid.UUID, args domain.UpsertGroupArgs) (*domain.Group, error) {
-	g, err := updateGroup(getTx(ctx, repo.db), groupID, args)
+	g, err := updateGroup(getTx(ctx, repo.db.WithContext(ctx)), groupID, args)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -34,28 +34,28 @@ func (repo *gormRepository) UpdateGroup(ctx context.Context, groupID uuid.UUID, 
 }
 
 func (repo *gormRepository) AddMemberToGroup(ctx context.Context, groupID, userID uuid.UUID) error {
-	err := addMemberToGroup(getTx(ctx, repo.db), groupID, userID)
+	err := addMemberToGroup(getTx(ctx, repo.db.WithContext(ctx)), groupID, userID)
 	return defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) DeleteGroup(ctx context.Context, groupID uuid.UUID) error {
-	err := deleteGroup(getTx(ctx, repo.db), groupID)
+	err := deleteGroup(getTx(ctx, repo.db.WithContext(ctx)), groupID)
 	return defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) DeleteMemberOfGroup(ctx context.Context, groupID, userID uuid.UUID) error {
-	err := deleteMemberOfGroup(getTx(ctx, repo.db), groupID, userID)
+	err := deleteMemberOfGroup(getTx(ctx, repo.db.WithContext(ctx)), groupID, userID)
 	return defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.Group, error) {
-	g, err := getGroup(groupFullPreload(getTx(ctx, repo.db)), groupID)
+	g, err := getGroup(groupFullPreload(getTx(ctx, repo.db.WithContext(ctx))), groupID)
 	domainGroup := convGroupTodomainGroup(*g)
 	return &domainGroup, defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) GetAllGroups(ctx context.Context) ([]*domain.Group, error) {
-	cmd := groupFullPreload(getTx(ctx, repo.db))
+	cmd := groupFullPreload(getTx(ctx, repo.db.WithContext(ctx)))
 	gs, err := getGroups(cmd.Joins(
 		"LEFT JOIN events ON groups.id = events.group_id "+
 			"LEFT JOIN group_members ON groups.id = group_members.group_id "+
@@ -65,7 +65,7 @@ func (repo *gormRepository) GetAllGroups(ctx context.Context) ([]*domain.Group, 
 }
 
 func (repo *gormRepository) GetBelongGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
-	cmd := groupFullPreload(getTx(ctx, repo.db))
+	cmd := groupFullPreload(getTx(ctx, repo.db.WithContext(ctx)))
 	filterFormat, filterArgs, err := createGroupFilter(filters.FilterBelongs(userID))
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (repo *gormRepository) GetBelongGroupIDs(ctx context.Context, userID uuid.U
 }
 
 func (repo *gormRepository) GetAdminGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
-	cmd := groupFullPreload(getTx(ctx, repo.db))
+	cmd := groupFullPreload(getTx(ctx, repo.db.WithContext(ctx)))
 	filterFormat, filterArgs, err := createGroupFilter(filters.FilterAdmins(userID))
 	if err != nil {
 		return nil, err

--- a/infra/db/room.go
+++ b/infra/db/room.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -16,8 +17,8 @@ func roomFullPreload(tx *gorm.DB) *gorm.DB {
 	return tx.Preload("Events").Preload("Admins").Preload("CreatedBy")
 }
 
-func (repo *gormRepository) CreateRoom(args domain.CreateRoomArgs) (*domain.Room, error) {
-	room, err := createRoom(repo.db, args)
+func (repo *gormRepository) CreateRoom(ctx context.Context, args domain.CreateRoomArgs) (*domain.Room, error) {
+	room, err := createRoom(getTx(ctx, repo.db), args)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -25,8 +26,8 @@ func (repo *gormRepository) CreateRoom(args domain.CreateRoomArgs) (*domain.Room
 	return &r, nil
 }
 
-func (repo *gormRepository) UpdateRoom(roomID uuid.UUID, args domain.UpdateRoomArgs) (*domain.Room, error) {
-	room, err := updateRoom(repo.db, roomID, args)
+func (repo *gormRepository) UpdateRoom(ctx context.Context, roomID uuid.UUID, args domain.UpdateRoomArgs) (*domain.Room, error) {
+	room, err := updateRoom(getTx(ctx, repo.db), roomID, args)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -34,21 +35,22 @@ func (repo *gormRepository) UpdateRoom(roomID uuid.UUID, args domain.UpdateRoomA
 	return &r, nil
 }
 
-func (repo *gormRepository) UpdateRoomVerified(roomID uuid.UUID, verified bool) error {
-	return updateRoomVerified(repo.db, roomID, verified)
+func (repo *gormRepository) UpdateRoomVerified(ctx context.Context, roomID uuid.UUID, verified bool) error {
+	return updateRoomVerified(getTx(ctx, repo.db), roomID, verified)
 }
 
-func (repo *gormRepository) DeleteRoom(roomID uuid.UUID) error {
-	return deleteRoom(repo.db, roomID)
+func (repo *gormRepository) DeleteRoom(ctx context.Context, roomID uuid.UUID) error {
+	return deleteRoom(getTx(ctx, repo.db), roomID)
 }
 
-func (repo *gormRepository) GetRoom(roomID uuid.UUID, excludeEventID uuid.UUID) (*domain.Room, error) {
+func (repo *gormRepository) GetRoom(ctx context.Context, roomID uuid.UUID, excludeEventID uuid.UUID) (*domain.Room, error) {
 	var room *Room
 	var err error
+	tx := getTx(ctx, repo.db)
 	if excludeEventID == uuid.Nil {
-		room, err = getRoom(roomFullPreload(repo.db), roomID)
+		room, err = getRoom(roomFullPreload(tx), roomID)
 	} else {
-		room, err = getRoom(roomExcludeEventPreload(repo.db, excludeEventID), roomID)
+		room, err = getRoom(roomExcludeEventPreload(tx, excludeEventID), roomID)
 	}
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -57,13 +59,14 @@ func (repo *gormRepository) GetRoom(roomID uuid.UUID, excludeEventID uuid.UUID) 
 	return &r, nil
 }
 
-func (repo *gormRepository) GetAllRooms(start, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
+func (repo *gormRepository) GetAllRooms(ctx context.Context, start, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
 	var rooms []*Room
 	var err error
+	tx := getTx(ctx, repo.db)
 	if excludeEventID == uuid.Nil {
-		rooms, err = getAllRooms(roomFullPreload(repo.db), start, end)
+		rooms, err = getAllRooms(roomFullPreload(tx), start, end)
 	} else {
-		rooms, err = getAllRooms(roomExcludeEventPreload(repo.db, excludeEventID), start, end)
+		rooms, err = getAllRooms(roomExcludeEventPreload(tx, excludeEventID), start, end)
 	}
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -107,7 +110,7 @@ func createRoom(db *gorm.DB, args domain.CreateRoomArgs) (*Room, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// 時間整合性は service で確認済み
 	return &room, err
 }

--- a/infra/db/room.go
+++ b/infra/db/room.go
@@ -18,7 +18,7 @@ func roomFullPreload(tx *gorm.DB) *gorm.DB {
 }
 
 func (repo *gormRepository) CreateRoom(ctx context.Context, args domain.CreateRoomArgs) (*domain.Room, error) {
-	room, err := createRoom(getTx(ctx, repo.db), args)
+	room, err := createRoom(getTx(ctx, repo.db.WithContext(ctx)), args)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -27,7 +27,7 @@ func (repo *gormRepository) CreateRoom(ctx context.Context, args domain.CreateRo
 }
 
 func (repo *gormRepository) UpdateRoom(ctx context.Context, roomID uuid.UUID, args domain.UpdateRoomArgs) (*domain.Room, error) {
-	room, err := updateRoom(getTx(ctx, repo.db), roomID, args)
+	room, err := updateRoom(getTx(ctx, repo.db.WithContext(ctx)), roomID, args)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -36,17 +36,17 @@ func (repo *gormRepository) UpdateRoom(ctx context.Context, roomID uuid.UUID, ar
 }
 
 func (repo *gormRepository) UpdateRoomVerified(ctx context.Context, roomID uuid.UUID, verified bool) error {
-	return updateRoomVerified(getTx(ctx, repo.db), roomID, verified)
+	return updateRoomVerified(getTx(ctx, repo.db.WithContext(ctx)), roomID, verified)
 }
 
 func (repo *gormRepository) DeleteRoom(ctx context.Context, roomID uuid.UUID) error {
-	return deleteRoom(getTx(ctx, repo.db), roomID)
+	return deleteRoom(getTx(ctx, repo.db.WithContext(ctx)), roomID)
 }
 
 func (repo *gormRepository) GetRoom(ctx context.Context, roomID uuid.UUID, excludeEventID uuid.UUID) (*domain.Room, error) {
 	var room *Room
 	var err error
-	tx := getTx(ctx, repo.db)
+	tx := getTx(ctx, repo.db.WithContext(ctx))
 	if excludeEventID == uuid.Nil {
 		room, err = getRoom(roomFullPreload(tx), roomID)
 	} else {
@@ -62,7 +62,7 @@ func (repo *gormRepository) GetRoom(ctx context.Context, roomID uuid.UUID, exclu
 func (repo *gormRepository) GetAllRooms(ctx context.Context, start, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
 	var rooms []*Room
 	var err error
-	tx := getTx(ctx, repo.db)
+	tx := getTx(ctx, repo.db.WithContext(ctx))
 	if excludeEventID == uuid.Nil {
 		rooms, err = getAllRooms(roomFullPreload(tx), start, end)
 	} else {

--- a/infra/db/room_test.go
+++ b/infra/db/room_test.go
@@ -13,7 +13,6 @@ import (
 func Test_createRoom(t *testing.T) {
 	r, assert, require, user := setupRepoWithUser(t, common)
 
-	println(user.Privilege)
 	params := domain.CreateRoomArgs{
 		CreatedBy: user.ID,
 		Verified:  false,

--- a/infra/db/tag.go
+++ b/infra/db/tag.go
@@ -1,13 +1,15 @@
 package db
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/knoQ/domain"
 	"gorm.io/gorm"
 )
 
-func (repo *gormRepository) CreateOrGetTag(name string) (*domain.Tag, error) {
-	tag, err := createOrGetTag(repo.db, name)
+func (repo *gormRepository) CreateOrGetTag(ctx context.Context, name string) (*domain.Tag, error) {
+	tag, err := createOrGetTag(getTx(ctx, repo.db), name)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -15,8 +17,8 @@ func (repo *gormRepository) CreateOrGetTag(name string) (*domain.Tag, error) {
 	return &t, nil
 }
 
-func (repo *gormRepository) GetTag(tagID uuid.UUID) (*domain.Tag, error) {
-	tag, err := getTag(repo.db, tagID)
+func (repo *gormRepository) GetTag(ctx context.Context, tagID uuid.UUID) (*domain.Tag, error) {
+	tag, err := getTag(getTx(ctx, repo.db), tagID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -24,8 +26,8 @@ func (repo *gormRepository) GetTag(tagID uuid.UUID) (*domain.Tag, error) {
 	return &t, nil
 }
 
-func (repo *gormRepository) GetAllTags() ([]*domain.Tag, error) {
-	tags, err := getAllTags(repo.db)
+func (repo *gormRepository) GetAllTags(ctx context.Context) ([]*domain.Tag, error) {
+	tags, err := getAllTags(getTx(ctx, repo.db))
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -34,7 +36,7 @@ func (repo *gormRepository) GetAllTags() ([]*domain.Tag, error) {
 }
 
 func createOrGetTag(db *gorm.DB, name string) (*Tag, error) {
-	id,err :=  uuid.NewV4()
+	id, err := uuid.NewV4()
 	if err != nil {
 		return nil, err
 	}

--- a/infra/db/tag.go
+++ b/infra/db/tag.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (repo *gormRepository) CreateOrGetTag(ctx context.Context, name string) (*domain.Tag, error) {
-	tag, err := createOrGetTag(getTx(ctx, repo.db), name)
+	tag, err := createOrGetTag(getTx(ctx, repo.db.WithContext(ctx)), name)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -18,7 +18,7 @@ func (repo *gormRepository) CreateOrGetTag(ctx context.Context, name string) (*d
 }
 
 func (repo *gormRepository) GetTag(ctx context.Context, tagID uuid.UUID) (*domain.Tag, error) {
-	tag, err := getTag(getTx(ctx, repo.db), tagID)
+	tag, err := getTag(getTx(ctx, repo.db.WithContext(ctx)), tagID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -27,7 +27,7 @@ func (repo *gormRepository) GetTag(ctx context.Context, tagID uuid.UUID) (*domai
 }
 
 func (repo *gormRepository) GetAllTags(ctx context.Context) ([]*domain.Tag, error) {
-	tags, err := getAllTags(getTx(ctx, repo.db))
+	tags, err := getAllTags(getTx(ctx, repo.db.WithContext(ctx)))
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}

--- a/infra/db/token.go
+++ b/infra/db/token.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (repo *gormRepository) GetToken(ctx context.Context, userID uuid.UUID) (*oauth2.Token, error) {
-	return getToken(getTx(ctx, repo.db), userID)
+	return getToken(getTx(ctx, repo.db.WithContext(ctx)), userID)
 }
 
 func getToken(db *gorm.DB, userID uuid.UUID) (*oauth2.Token, error) {

--- a/infra/db/token.go
+++ b/infra/db/token.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -10,8 +11,8 @@ import (
 	"gorm.io/gorm"
 )
 
-func (repo *gormRepository) GetToken(userID uuid.UUID) (*oauth2.Token, error) {
-	return getToken(repo.db, userID)
+func (repo *gormRepository) GetToken(ctx context.Context, userID uuid.UUID) (*oauth2.Token, error) {
+	return getToken(getTx(ctx, repo.db), userID)
 }
 
 func getToken(db *gorm.DB, userID uuid.UUID) (*oauth2.Token, error) {
@@ -89,5 +90,5 @@ func saveToken(db *gorm.DB, token *Token) error {
 			token.AccessToken = string(cipherText)
 		}
 	}
-	return db.Save(token).Error 
+	return db.Save(token).Error
 }

--- a/infra/db/transaction.go
+++ b/infra/db/transaction.go
@@ -1,0 +1,35 @@
+package db
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type gormTransactionManager struct {
+	db *gorm.DB
+}
+
+// context用のキー
+type txKey struct{}
+
+func NewTransactionManager(db *gorm.DB) *gormTransactionManager {
+	return &gormTransactionManager{db: db}
+}
+
+// Service以上でtransactionを張りたい場合
+func (repo *gormRepository) Do(ctx context.Context, fn func(ctx context.Context) error) error {
+	return repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// トランザクション(tx)をcontextにセットして実行
+		ctxWithTx := context.WithValue(ctx, txKey{}, tx)
+		return fn(ctxWithTx)
+	})
+}
+
+// transactionを張らなくてもデフォルトのdbで実行できる
+func getTx(ctx context.Context, defaultDB *gorm.DB) *gorm.DB {
+	if tx, ok := ctx.Value(txKey{}).(*gorm.DB); ok {
+		return tx
+	}
+	return defaultDB
+}

--- a/infra/db/transaction.go
+++ b/infra/db/transaction.go
@@ -18,9 +18,9 @@ func NewTransactionManager(db *gorm.DB) *gormTransactionManager {
 }
 
 // Service以上でtransactionを張りたい場合
-func (repo *gormRepository) Do(ctx context.Context, fn func(ctx context.Context) error) error {
+func (repo *gormTransactionManager) Do(ctx context.Context, fn func(ctx context.Context) error) error {
 	return repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// トランザクション(tx)をcontextにセットして実行
+		// トランザクションをcontextにセットして実行
 		ctxWithTx := context.WithValue(ctx, txKey{}, tx)
 		return fn(ctxWithTx)
 	})

--- a/infra/db/transaction.go
+++ b/infra/db/transaction.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 
+	"github.com/traPtitech/knoQ/domain"
 	"gorm.io/gorm"
 )
 
@@ -13,13 +14,14 @@ type gormTransactionManager struct {
 // context用のキー
 type txKey struct{}
 
-func NewTransactionManager(db *gorm.DB) *gormTransactionManager {
+func NewTransactionManager(db *gorm.DB) domain.TransactionManager {
 	return &gormTransactionManager{db: db}
 }
 
 // Service以上でtransactionを張りたい場合
 func (repo *gormTransactionManager) Do(ctx context.Context, fn func(ctx context.Context) error) error {
-	return repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	tx := getTx(ctx, repo.db)
+	return tx.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// トランザクションをcontextにセットして実行
 		ctxWithTx := context.WithValue(ctx, txKey{}, tx)
 		return fn(ctxWithTx)

--- a/infra/db/user.go
+++ b/infra/db/user.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"errors"
 
 	"github.com/gofrs/uuid"
@@ -14,7 +15,7 @@ func userPreload(tx *gorm.DB) *gorm.DB {
 }
 
 // LoginUser のときのみ，プロバイダ，トークン情報が含まれる
-func (repo *gormRepository) SaveUser(args domain.SaveUserArgs) (*domain.User, error) {
+func (repo *gormRepository) SaveUser(ctx context.Context, args domain.SaveUserArgs) (*domain.User, error) {
 	user := User{
 		ID:    args.UserID,
 		State: args.State,
@@ -33,24 +34,27 @@ func (repo *gormRepository) SaveUser(args domain.SaveUserArgs) (*domain.User, er
 			Subject: args.Subject,
 		},
 	}
-	u, err := saveUser(repo.db, &user)
+	u, err := saveUser(getTx(ctx, repo.db), &user)
+	if err != nil {
+		return nil, defaultErrorHandling(err)
+	}
 	du := convUserTodomainUser(*u)
 	return &du, defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) UpdateiCalSecret(userID uuid.UUID, secret string) error {
-	err := updateiCalSecret(repo.db, userID, secret)
+func (repo *gormRepository) UpdateiCalSecret(ctx context.Context, userID uuid.UUID, secret string) error {
+	err := updateiCalSecret(getTx(ctx, repo.db), userID, secret)
 	return defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) GetUser(userID uuid.UUID) (*domain.User, error) {
-	u, err := getUser(userPreload(repo.db), userID)
+func (repo *gormRepository) GetUser(ctx context.Context, userID uuid.UUID) (*domain.User, error) {
+	u, err := getUser(userPreload(getTx(ctx, repo.db)), userID)
 	du := convUserTodomainUser(*u)
 	return &du, defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) GetAllUsers(onlyActive bool) ([]*domain.User, error) {
-	us, err := getAllUsers(userPreload(repo.db), onlyActive)
+func (repo *gormRepository) GetAllUsers(ctx context.Context, onlyActive bool) ([]*domain.User, error) {
+	us, err := getAllUsers(userPreload(getTx(ctx, repo.db)), onlyActive)
 	dus := lo.Map(us, func(u *User, _ int) *domain.User {
 		return &domain.User{
 			ID:         u.ID,
@@ -65,9 +69,9 @@ func (repo *gormRepository) GetAllUsers(onlyActive bool) ([]*domain.User, error)
 	return dus, defaultErrorHandling(err)
 }
 
-func (repo *gormRepository) SyncUsers(args []domain.SyncUserArgs) error {
-
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+func (repo *gormRepository) SyncUsers(ctx context.Context, args []domain.SyncUserArgs) error {
+	tx := getTx(ctx, repo.db)
+	err := tx.Transaction(func(tx *gorm.DB) error {
 		existingUsers, err := getAllUsers(tx, false)
 		if err != nil {
 			return err
@@ -129,7 +133,7 @@ func saveUser(db *gorm.DB, user *User) (*User, error) {
 			// 関連の作成
 			err := tx.Create(user).Error
 			if err != nil {
-				return err;
+				return err
 			}
 			if user.Provider.UserID != uuid.Nil {
 				err = tx.Save(user.Provider).Error
@@ -190,8 +194,8 @@ func getAllUsers(db *gorm.DB, onlyActive bool) ([]*User, error) {
 	return users, err
 }
 
-func (repo *gormRepository) GrantPrivilege(userID uuid.UUID) error {
-	err := grantPrivilege(repo.db, userID)
+func (repo *gormRepository) GrantPrivilege(ctx context.Context, userID uuid.UUID) error {
+	err := grantPrivilege(getTx(ctx, repo.db), userID)
 	return defaultErrorHandling(err)
 }
 
@@ -200,8 +204,8 @@ func grantPrivilege(db *gorm.DB, userID uuid.UUID) error {
 	return err
 }
 
-func (repo *gormRepository) GetICalSecret(userID uuid.UUID) (string, error) {
-	u, err := getUser(repo.db, userID)
+func (repo *gormRepository) GetICalSecret(ctx context.Context, userID uuid.UUID) (string, error) {
+	u, err := getUser(getTx(ctx, repo.db), userID)
 	if err != nil {
 		return "", defaultErrorHandling(err)
 	}

--- a/infra/db/user.go
+++ b/infra/db/user.go
@@ -34,7 +34,7 @@ func (repo *gormRepository) SaveUser(ctx context.Context, args domain.SaveUserAr
 			Subject: args.Subject,
 		},
 	}
-	u, err := saveUser(getTx(ctx, repo.db), &user)
+	u, err := saveUser(getTx(ctx, repo.db.WithContext(ctx)), &user)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -43,18 +43,18 @@ func (repo *gormRepository) SaveUser(ctx context.Context, args domain.SaveUserAr
 }
 
 func (repo *gormRepository) UpdateiCalSecret(ctx context.Context, userID uuid.UUID, secret string) error {
-	err := updateiCalSecret(getTx(ctx, repo.db), userID, secret)
+	err := updateiCalSecret(getTx(ctx, repo.db.WithContext(ctx)), userID, secret)
 	return defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) GetUser(ctx context.Context, userID uuid.UUID) (*domain.User, error) {
-	u, err := getUser(userPreload(getTx(ctx, repo.db)), userID)
+	u, err := getUser(userPreload(getTx(ctx, repo.db.WithContext(ctx))), userID)
 	du := convUserTodomainUser(*u)
 	return &du, defaultErrorHandling(err)
 }
 
 func (repo *gormRepository) GetAllUsers(ctx context.Context, onlyActive bool) ([]*domain.User, error) {
-	us, err := getAllUsers(userPreload(getTx(ctx, repo.db)), onlyActive)
+	us, err := getAllUsers(userPreload(getTx(ctx, repo.db.WithContext(ctx))), onlyActive)
 	dus := lo.Map(us, func(u *User, _ int) *domain.User {
 		return &domain.User{
 			ID:         u.ID,
@@ -70,7 +70,7 @@ func (repo *gormRepository) GetAllUsers(ctx context.Context, onlyActive bool) ([
 }
 
 func (repo *gormRepository) SyncUsers(ctx context.Context, args []domain.SyncUserArgs) error {
-	tx := getTx(ctx, repo.db)
+	tx := getTx(ctx, repo.db.WithContext(ctx))
 	err := tx.Transaction(func(tx *gorm.DB) error {
 		existingUsers, err := getAllUsers(tx, false)
 		if err != nil {
@@ -195,7 +195,7 @@ func getAllUsers(db *gorm.DB, onlyActive bool) ([]*User, error) {
 }
 
 func (repo *gormRepository) GrantPrivilege(ctx context.Context, userID uuid.UUID) error {
-	err := grantPrivilege(getTx(ctx, repo.db), userID)
+	err := grantPrivilege(getTx(ctx, repo.db.WithContext(ctx)), userID)
 	return defaultErrorHandling(err)
 }
 
@@ -205,7 +205,7 @@ func grantPrivilege(db *gorm.DB, userID uuid.UUID) error {
 }
 
 func (repo *gormRepository) GetICalSecret(ctx context.Context, userID uuid.UUID) (string, error) {
-	u, err := getUser(getTx(ctx, repo.db), userID)
+	u, err := getUser(getTx(ctx, repo.db.WithContext(ctx)), userID)
 	if err != nil {
 		return "", defaultErrorHandling(err)
 	}

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	domain.REVISION = revision
 	domain.DEVELOPMENT, _ = strconv.ParseBool(development)
 
-	gormRepo, err := db.NewRepository(mariadbHost, mariadbUser, mariadbPassword, mariadbDatabase, mariadbPort, tokenKey, gormLogLevel, tz.JST)
+	gormRepo, txManager, err := db.NewRepository(mariadbHost, mariadbUser, mariadbPassword, mariadbDatabase, mariadbPort, tokenKey, gormLogLevel, tz.JST)
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ func main() {
 		URL:               "https://q.trap.jp/api/v3",
 		ServerAccessToken: traqAccessToken,
 	}
-	s := service.NewService(gormRepo, &traqRepo)
+	s := service.NewService(gormRepo, &traqRepo, txManager)
 	handler := &router.Handlers{
 		Service:    s,
 		Logger:     logger,

--- a/service/event_impl.go
+++ b/service/event_impl.go
@@ -47,7 +47,7 @@ func (s *service) CreateEvent(ctx context.Context, reqID uuid.UUID, params domai
 
 		eventResp, err = s.GormRepo.CreateEvent(ctx, p)
 		if err != nil {
-			return defaultErrorHandling(err)
+			return err
 		}
 		for _, groupMember := range group.Members {
 			err = s.GormRepo.UpsertEventSchedule(ctx, eventResp.ID, groupMember.ID, domain.Pending)
@@ -118,7 +118,7 @@ func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 		var err error
 		eventResp, err = s.GormRepo.UpdateEvent(ctx, eventID, p)
 		if err != nil {
-			return defaultErrorHandling(err)
+			return err
 		}
 		for _, groupMember := range group.Members {
 			exist := false

--- a/service/event_impl.go
+++ b/service/event_impl.go
@@ -17,40 +17,48 @@ func (s *service) CreateEvent(ctx context.Context, reqID uuid.UUID, params domai
 	if !params.TimeConsistency() {
 		return nil, ErrTimeConsistency
 	}
+	var eventResp *domain.Event
 
-	p := domain.UpsertEventArgs{
-		WriteEventParams: params,
-		CreatedBy:        reqID,
-	}
-
-	if params.RoomID == uuid.Nil {
-		if params.Place != "" {
-			roomParams := domain.WriteRoomParams{
-				Place:     params.Place,
-				TimeStart: params.TimeStart,
-				TimeEnd:   params.TimeEnd,
-				Admins:    params.Admins,
-			}
-			// UnVerifiedを仮定
-			var r *domain.Room
-			r, err = s.CreateUnVerifiedRoom(ctx, reqID, roomParams)
-			p.RoomID = r.ID
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, ErrRoomUndefined
+	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
+		p := domain.UpsertEventArgs{
+			WriteEventParams: params,
+			CreatedBy:        reqID,
 		}
-	}
 
-	event, err := s.GormRepo.CreateEvent(p)
+		if params.RoomID == uuid.Nil {
+			if params.Place != "" {
+				roomParams := domain.WriteRoomParams{
+					Place:     params.Place,
+					TimeStart: params.TimeStart,
+					TimeEnd:   params.TimeEnd,
+					Admins:    params.Admins,
+				}
+				// UnVerifiedを仮定
+				var r *domain.Room
+				r, err = s.CreateUnVerifiedRoom(ctx, reqID, roomParams)
+				p.RoomID = r.ID
+				if err != nil {
+					return err
+				}
+			} else {
+				return ErrRoomUndefined
+			}
+		}
+
+		eventResp, err = s.GormRepo.CreateEvent(ctx, p)
+		if err != nil {
+			return defaultErrorHandling(err)
+		}
+		for _, groupMember := range group.Members {
+			_ = s.GormRepo.UpsertEventSchedule(ctx, eventResp.ID, groupMember.ID, domain.Pending)
+		}
+		return nil
+	})
+
 	if err != nil {
-		return nil, defaultErrorHandling(err)
+		return nil, err
 	}
-	for _, groupMember := range group.Members {
-		_ = s.GormRepo.UpsertEventSchedule(event.ID, groupMember.ID, domain.Pending)
-	}
-	return s.GetEvent(ctx, event.ID)
+	return s.GetEvent(ctx, eventResp.ID)
 }
 
 func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid.UUID, params domain.WriteEventParams) (*domain.Event, error) {
@@ -73,54 +81,61 @@ func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 		return nil, ErrTimeConsistency
 	}
 
-	p := domain.UpsertEventArgs{
-		WriteEventParams: params,
-		CreatedBy:        reqID,
-	}
+	var eventResp domain.Event
+	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
+		p := domain.UpsertEventArgs{
+			WriteEventParams: params,
+			CreatedBy:        reqID,
+		}
 
-	// RoomIDの存在を確認 RoomがなくPlaceがあれば新たに作成
-	if params.RoomID == uuid.Nil {
-		if currentEvent.Room.ID != uuid.Nil {
-			p.RoomID = currentEvent.Room.ID
-		} else {
-			if params.Place != "" {
-				roomParams := domain.WriteRoomParams{
-					Place:     params.Place,
-					TimeStart: params.TimeStart,
-					TimeEnd:   params.TimeEnd,
-					Admins:    params.Admins,
-				}
-				// UnVerifiedを仮定
-				var r *domain.Room
-				r, err = s.CreateUnVerifiedRoom(ctx, reqID, roomParams)
-				if err != nil {
-					return nil, err
-				}
-				p.RoomID = r.ID
+		// RoomIDの存在を確認 RoomがなくPlaceがあれば新たに作成
+		if params.RoomID == uuid.Nil {
+			if currentEvent.Room.ID != uuid.Nil {
+				p.RoomID = currentEvent.Room.ID
 			} else {
-				return nil, ErrRoomUndefined
+				if params.Place != "" {
+					roomParams := domain.WriteRoomParams{
+						Place:     params.Place,
+						TimeStart: params.TimeStart,
+						TimeEnd:   params.TimeEnd,
+						Admins:    params.Admins,
+					}
+					// UnVerifiedを仮定
+					var r *domain.Room
+					r, err = s.CreateUnVerifiedRoom(ctx, reqID, roomParams)
+					if err != nil {
+						return err
+					}
+					p.RoomID = r.ID
+				} else {
+					return ErrRoomUndefined
+				}
 			}
 		}
-	}
 
-	// Event Save を使っている
-	event, err := s.GormRepo.UpdateEvent(eventID, p)
+		eventResp, err := s.GormRepo.UpdateEvent(ctx, eventID, p)
+		if err != nil {
+			return defaultErrorHandling(err)
+		}
+		for _, groupMember := range group.Members {
+			exist := false
+			for _, currentAttendee := range currentEvent.Attendees {
+				if currentAttendee.UserID == groupMember.ID {
+					exist = true
+				}
+			}
+			if !exist {
+				_ = s.GormRepo.UpsertEventSchedule(ctx, eventResp.ID, groupMember.ID, domain.Pending)
+			}
+
+		}
+		return nil
+	})
+
 	if err != nil {
-		return nil, defaultErrorHandling(err)
+		return nil, err
 	}
-	for _, groupMember := range group.Members {
-		exist := false
-		for _, currentAttendee := range currentEvent.Attendees {
-			if currentAttendee.UserID == groupMember.ID {
-				exist = true
-			}
-		}
-		if !exist {
-			_ = s.GormRepo.UpsertEventSchedule(event.ID, groupMember.ID, domain.Pending)
-		}
-
-	}
-	return s.GetEvent(ctx, event.ID)
+	return s.GetEvent(ctx, eventResp.ID)
 }
 
 func (s *service) AddEventTag(ctx context.Context, reqID uuid.UUID, eventID uuid.UUID, tagName string, locked bool) error {
@@ -128,9 +143,13 @@ func (s *service) AddEventTag(ctx context.Context, reqID uuid.UUID, eventID uuid
 	if locked && !s.IsEventAdmins(ctx, reqID, eventID) {
 		return domain.ErrForbidden
 	}
-	return s.GormRepo.AddEventTag(eventID, domain.EventTagParams{
-		Name: tagName, Locked: locked,
+
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return s.GormRepo.AddEventTag(ctx, eventID, domain.EventTagParams{
+			Name: tagName, Locked: locked,
+		})
 	})
+	return err
 }
 
 func (s *service) DeleteEvent(ctx context.Context, reqID uuid.UUID, eventID uuid.UUID) error {
@@ -138,18 +157,24 @@ func (s *service) DeleteEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 		return domain.ErrForbidden
 	}
 
-	return s.GormRepo.DeleteEvent(eventID)
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return  s.GormRepo.DeleteEvent(ctx, eventID)
+	})
+	return err
 }
 
 // DeleteTagInEvent delete a tag in that Event
 func (s *service) DeleteEventTag(ctx context.Context, reqID uuid.UUID, eventID uuid.UUID, tagName string) error {
 	deleteLocked := s.IsEventAdmins(ctx, reqID, eventID)
 
-	return s.GormRepo.DeleteEventTag(eventID, tagName, deleteLocked)
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return s.GormRepo.DeleteEventTag(ctx, eventID, tagName, deleteLocked)
+	})
+	return err
 }
 
 func (s *service) GetEvent(ctx context.Context, eventID uuid.UUID) (*domain.Event, error) {
-	event, err := s.GormRepo.GetEvent(eventID)
+	event, err := s.GormRepo.GetEvent(ctx, eventID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -188,15 +213,17 @@ func (s *service) UpsertMeEventSchedule(ctx context.Context, reqID uuid.UUID, ev
 		return domain.ErrForbidden
 	}
 
-	err = s.GormRepo.UpsertEventSchedule(eventID, reqID, schedule)
+	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return s.GormRepo.UpsertEventSchedule(ctx, eventID, reqID, schedule)
+	})
 	return defaultErrorHandling(err)
 }
 
 func (s *service) GetEvents(ctx context.Context, reqID uuid.UUID, expr filters.Expr) ([]*domain.Event, error) {
 
-	expr = addTraQGroupIDs(s, reqID, expr)
+	expr = addTraQGroupIDs(ctx, s, reqID, expr)
 
-	es, err := s.GormRepo.GetAllEvents(expr)
+	es, err := s.GormRepo.GetAllEvents(ctx, expr)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -205,9 +232,9 @@ func (s *service) GetEvents(ctx context.Context, reqID uuid.UUID, expr filters.E
 }
 
 func (s *service) GetEventsWithGroup(ctx context.Context, reqID uuid.UUID, expr filters.Expr) ([]*domain.Event, error) {
-	expr = addTraQGroupIDs(s, reqID, expr)
+	expr = addTraQGroupIDs(ctx, s, reqID, expr)
 
-	events, err := s.GormRepo.GetAllEvents(expr)
+	events, err := s.GormRepo.GetAllEvents(ctx, expr)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -244,7 +271,7 @@ func (s *service) GetEventsWithGroup(ctx context.Context, reqID uuid.UUID, expr 
 }
 
 func (s *service) IsEventAdmins(ctx context.Context, reqID uuid.UUID, eventID uuid.UUID) bool {
-	event, err := s.GormRepo.GetEvent(eventID)
+	event, err := s.GormRepo.GetEvent(ctx, eventID)
 	if err != nil {
 		return false
 	}
@@ -273,8 +300,8 @@ func createUserMap(users []*domain.User) map[uuid.UUID]*domain.User {
 }
 
 // add traQ group and traP(111...)
-func addTraQGroupIDs(s *service, userID uuid.UUID, expr filters.Expr) filters.Expr {
-	t, err := s.GormRepo.GetToken(userID)
+func addTraQGroupIDs(ctx context.Context, s *service, userID uuid.UUID, expr filters.Expr) filters.Expr {
+	t, err := s.GormRepo.GetToken(ctx, userID)
 	if err != nil {
 		return expr
 	}
@@ -294,7 +321,7 @@ func addTraQGroupIDs(s *service, userID uuid.UUID, expr filters.Expr) filters.Ex
 					return e
 				}
 				// add traP
-				user, err := s.GormRepo.GetUser(id)
+				user, err := s.GormRepo.GetUser(ctx, id)
 				if err != nil {
 					return e
 				}

--- a/service/event_impl.go
+++ b/service/event_impl.go
@@ -17,8 +17,8 @@ func (s *service) CreateEvent(ctx context.Context, reqID uuid.UUID, params domai
 	if !params.TimeConsistency() {
 		return nil, ErrTimeConsistency
 	}
-	var eventResp *domain.Event
 
+	var eventResp *domain.Event
 	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
 		p := domain.UpsertEventArgs{
 			WriteEventParams: params,
@@ -36,10 +36,10 @@ func (s *service) CreateEvent(ctx context.Context, reqID uuid.UUID, params domai
 				// UnVerifiedを仮定
 				var r *domain.Room
 				r, err = s.CreateUnVerifiedRoom(ctx, reqID, roomParams)
-				p.RoomID = r.ID
 				if err != nil {
 					return err
 				}
+				p.RoomID = r.ID
 			} else {
 				return ErrRoomUndefined
 			}
@@ -50,7 +50,10 @@ func (s *service) CreateEvent(ctx context.Context, reqID uuid.UUID, params domai
 			return defaultErrorHandling(err)
 		}
 		for _, groupMember := range group.Members {
-			_ = s.GormRepo.UpsertEventSchedule(ctx, eventResp.ID, groupMember.ID, domain.Pending)
+			err = s.GormRepo.UpsertEventSchedule(ctx, eventResp.ID, groupMember.ID, domain.Pending)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -81,7 +84,7 @@ func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 		return nil, ErrTimeConsistency
 	}
 
-	var eventResp domain.Event
+	var eventResp *domain.Event
 	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
 		p := domain.UpsertEventArgs{
 			WriteEventParams: params,
@@ -112,8 +115,8 @@ func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 				}
 			}
 		}
-
-		eventResp, err := s.GormRepo.UpdateEvent(ctx, eventID, p)
+		var err error
+		eventResp, err = s.GormRepo.UpdateEvent(ctx, eventID, p)
 		if err != nil {
 			return defaultErrorHandling(err)
 		}
@@ -158,7 +161,7 @@ func (s *service) DeleteEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 	}
 
 	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
-		return  s.GormRepo.DeleteEvent(ctx, eventID)
+		return s.GormRepo.DeleteEvent(ctx, eventID)
 	})
 	return err
 }

--- a/service/event_impl.go
+++ b/service/event_impl.go
@@ -128,7 +128,10 @@ func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 				}
 			}
 			if !exist {
-				_ = s.GormRepo.UpsertEventSchedule(ctx, eventResp.ID, groupMember.ID, domain.Pending)
+				err = s.GormRepo.UpsertEventSchedule(ctx, eventResp.ID, groupMember.ID, domain.Pending)
+				if err != nil {
+					return err
+				}
 			}
 
 		}

--- a/service/group_impl.go
+++ b/service/group_impl.go
@@ -17,7 +17,7 @@ func (s *service) CreateGroup(ctx context.Context, reqID uuid.UUID, params domai
 		WriteGroupParams: params,
 		CreatedBy:        reqID,
 	}
-	g, err := s.GormRepo.CreateGroup(p)
+	g, err := s.GormRepo.CreateGroup(ctx, p)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -33,12 +33,17 @@ func (s *service) UpdateGroup(ctx context.Context, reqID uuid.UUID, groupID uuid
 		WriteGroupParams: params,
 		CreatedBy:        reqID,
 	}
-	g, err := s.GormRepo.UpdateGroup(groupID, p)
+	var groupResp *domain.Group
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		var err error
+		groupResp, err = s.GormRepo.UpdateGroup(ctx, groupID, p)
+		return err
+	})
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
 
-	return g, nil
+	return groupResp, nil
 }
 
 // AddMeToGroup add me to that group if that group is open.
@@ -47,14 +52,21 @@ func (s *service) AddMeToGroup(ctx context.Context, reqID uuid.UUID, groupID uui
 	if !s.IsGroupJoinFreely(ctx, groupID) {
 		return domain.ErrForbidden
 	}
-	return s.GormRepo.AddMemberToGroup(groupID, reqID)
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return s.GormRepo.AddMemberToGroup(ctx, groupID, reqID)
+	})
+	return err
 }
 
 func (s *service) DeleteGroup(ctx context.Context, reqID uuid.UUID, groupID uuid.UUID) error {
 	if !s.IsGroupAdmins(ctx, reqID, groupID) {
 		return domain.ErrForbidden
 	}
-	return s.GormRepo.DeleteGroup(groupID)
+
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return s.GormRepo.DeleteGroup(ctx, groupID)
+	})
+	return err
 }
 
 // DeleteMeGroup delete me in that group if that group is open.
@@ -62,11 +74,11 @@ func (s *service) DeleteMeGroup(ctx context.Context, reqID uuid.UUID, groupID uu
 	if !s.IsGroupJoinFreely(ctx, groupID) {
 		return domain.ErrForbidden
 	}
-	return s.GormRepo.DeleteMemberOfGroup(groupID, reqID)
+	return s.GormRepo.DeleteMemberOfGroup(ctx, groupID, reqID)
 }
 
 func (s *service) GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.Group, error) {
-	domainGroup, err := s.GormRepo.GetGroup(groupID)
+	domainGroup, err := s.GormRepo.GetGroup(ctx, groupID)
 	if err == nil {
 		return domainGroup, nil
 	}
@@ -96,7 +108,7 @@ func (s *service) GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.Grou
 
 func (s *service) GetAllGroups(ctx context.Context) ([]*domain.Group, error) {
 	groups := make([]*domain.Group, 0)
-	gg, err := s.GormRepo.GetAllGroups()
+	gg, err := s.GormRepo.GetAllGroups(ctx)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -118,11 +130,11 @@ func (s *service) GetAllGroups(ctx context.Context) ([]*domain.Group, error) {
 
 func (s *service) GetUserBelongingGroupIDs(ctx context.Context, reqID uuid.UUID, userID uuid.UUID) ([]uuid.UUID, error) {
 
-	t, err := s.GormRepo.GetToken(reqID)
+	t, err := s.GormRepo.GetToken(ctx, reqID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
-	ggIDs, err := s.GormRepo.GetBelongGroupIDs(userID)
+	ggIDs, err := s.GormRepo.GetBelongGroupIDs(ctx, userID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -135,11 +147,11 @@ func (s *service) GetUserBelongingGroupIDs(ctx context.Context, reqID uuid.UUID,
 }
 
 func (s *service) GetUserAdminGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
-	return s.GormRepo.GetAdminGroupIDs(userID)
+	return s.GormRepo.GetAdminGroupIDs(ctx, userID)
 }
 
 func (s *service) IsGroupAdmins(ctx context.Context, reqID uuid.UUID, groupID uuid.UUID) bool {
-	group, err := s.GormRepo.GetGroup(groupID)
+	group, err := s.GormRepo.GetGroup(ctx, groupID)
 	if err != nil {
 		return false
 	}
@@ -152,7 +164,7 @@ func (s *service) IsGroupAdmins(ctx context.Context, reqID uuid.UUID, groupID uu
 }
 
 func (s *service) IsGroupJoinFreely(ctx context.Context, groupID uuid.UUID) bool {
-	group, err := s.GormRepo.GetGroup(groupID)
+	group, err := s.GormRepo.GetGroup(ctx, groupID)
 	if err != nil {
 		return false
 	}

--- a/service/group_impl.go
+++ b/service/group_impl.go
@@ -17,12 +17,19 @@ func (s *service) CreateGroup(ctx context.Context, reqID uuid.UUID, params domai
 		WriteGroupParams: params,
 		CreatedBy:        reqID,
 	}
-	g, err := s.GormRepo.CreateGroup(ctx, p)
+
+	var groupResp *domain.Group
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		var err error
+		groupResp, err = s.GormRepo.CreateGroup(ctx, p)
+		return err
+	})
+
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
 
-	return g, nil
+	return groupResp, nil
 }
 
 func (s *service) UpdateGroup(ctx context.Context, reqID uuid.UUID, groupID uuid.UUID, params domain.WriteGroupParams) (*domain.Group, error) {
@@ -55,7 +62,7 @@ func (s *service) AddMeToGroup(ctx context.Context, reqID uuid.UUID, groupID uui
 	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
 		return s.GormRepo.AddMemberToGroup(ctx, groupID, reqID)
 	})
-	return err
+	return defaultErrorHandling(err)
 }
 
 func (s *service) DeleteGroup(ctx context.Context, reqID uuid.UUID, groupID uuid.UUID) error {
@@ -66,7 +73,7 @@ func (s *service) DeleteGroup(ctx context.Context, reqID uuid.UUID, groupID uuid
 	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
 		return s.GormRepo.DeleteGroup(ctx, groupID)
 	})
-	return err
+	return defaultErrorHandling(err)
 }
 
 // DeleteMeGroup delete me in that group if that group is open.
@@ -74,7 +81,11 @@ func (s *service) DeleteMeGroup(ctx context.Context, reqID uuid.UUID, groupID uu
 	if !s.IsGroupJoinFreely(ctx, groupID) {
 		return domain.ErrForbidden
 	}
-	return s.GormRepo.DeleteMemberOfGroup(ctx, groupID, reqID)
+
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return s.GormRepo.DeleteMemberOfGroup(ctx, groupID, reqID)
+	})
+	return defaultErrorHandling(err)
 }
 
 func (s *service) GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.Group, error) {

--- a/service/room_impl.go
+++ b/service/room_impl.go
@@ -17,8 +17,13 @@ func (s *service) CreateUnVerifiedRoom(ctx context.Context, reqID uuid.UUID, par
 		Verified:        false,
 		CreatedBy:       reqID,
 	}
-	r, err := s.GormRepo.CreateRoom(p)
-	return r, defaultErrorHandling(err)
+	var roomResp *domain.Room
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		var err error
+		roomResp, err = s.GormRepo.CreateRoom(ctx, p)
+		return err
+	})
+	return roomResp, defaultErrorHandling(err)
 }
 
 func (s *service) CreateVerifiedRoom(ctx context.Context, reqID uuid.UUID, params domain.WriteRoomParams) (*domain.Room, error) {
@@ -34,8 +39,14 @@ func (s *service) CreateVerifiedRoom(ctx context.Context, reqID uuid.UUID, param
 		Verified:        true,
 		CreatedBy:       reqID,
 	}
-	r, err := s.GormRepo.CreateRoom(p)
-	return r, defaultErrorHandling(err)
+
+	var roomResp *domain.Room
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		var err error
+		roomResp, err = s.GormRepo.CreateRoom(ctx, p)
+		return err
+	})
+	return roomResp, defaultErrorHandling(err)
 }
 
 func (s *service) UpdateRoom(ctx context.Context, reqID uuid.UUID, roomID uuid.UUID, params domain.WriteRoomParams) (*domain.Room, error) {
@@ -54,15 +65,26 @@ func (s *service) UpdateRoom(ctx context.Context, reqID uuid.UUID, roomID uuid.U
 	if !params.TimeConsistency() {
 		return nil, ErrTimeConsistency
 	}
-	r, err := s.GormRepo.UpdateRoom(roomID, p)
-	return r, defaultErrorHandling(err)
+
+	var roomResp *domain.Room
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		var err error
+		roomResp, err = s.GormRepo.UpdateRoom(ctx, roomID, p)
+		return err
+	})
+	return roomResp, defaultErrorHandling(err)
 }
 
 func (s *service) VerifyRoom(ctx context.Context, reqID uuid.UUID, roomID uuid.UUID) error {
 	if !s.IsPrivilege(ctx, reqID) {
 		return domain.ErrForbidden
 	}
-	err := s.GormRepo.UpdateRoomVerified(roomID, true)
+
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		err := s.GormRepo.UpdateRoomVerified(ctx, roomID, true)
+		return err
+	})
+
 	return defaultErrorHandling(err)
 }
 
@@ -70,7 +92,11 @@ func (s *service) UnVerifyRoom(ctx context.Context, reqID uuid.UUID, roomID uuid
 	if !s.IsPrivilege(ctx, reqID) {
 		return domain.ErrForbidden
 	}
-	err := s.GormRepo.UpdateRoomVerified(roomID, false)
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		err := s.GormRepo.UpdateRoomVerified(ctx, roomID, false)
+		return err
+	})
+
 	return defaultErrorHandling(err)
 }
 
@@ -78,17 +104,21 @@ func (s *service) DeleteRoom(ctx context.Context, reqID uuid.UUID, roomID uuid.U
 	if !s.IsRoomAdmins(ctx, reqID, roomID) {
 		return domain.ErrForbidden
 	}
-	err := s.GormRepo.DeleteRoom(roomID)
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		err := s.GormRepo.DeleteRoom(ctx, roomID)
+		return err
+	})
+
 	return defaultErrorHandling(err)
 }
 
 func (s *service) GetRoom(ctx context.Context, roomID uuid.UUID, excludeEventID uuid.UUID) (*domain.Room, error) {
-	rs, err := s.GormRepo.GetRoom(roomID, excludeEventID)
+	rs, err := s.GormRepo.GetRoom(ctx, roomID, excludeEventID)
 	return rs, defaultErrorHandling(err)
 }
 
 func (s *service) GetAllRooms(ctx context.Context, start time.Time, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
-	rs, err := s.GormRepo.GetAllRooms(start, end, excludeEventID)
+	rs, err := s.GormRepo.GetAllRooms(ctx, start, end, excludeEventID)
 	return rs, defaultErrorHandling(err)
 }
 

--- a/service/service_impl.go
+++ b/service/service_impl.go
@@ -6,12 +6,13 @@ import (
 )
 
 type service struct {
-	GormRepo domain.Repository
-	TraQRepo *traq.TraQRepository
+	GormRepo  domain.Repository
+	TraQRepo  *traq.TraQRepository
+	TxManager domain.TransactionManager
 }
 
 // implements domain
 
-func NewService(repo domain.Repository, traqRepo *traq.TraQRepository) domain.Service {
-	return &service{GormRepo: repo, TraQRepo: traqRepo}
+func NewService(repo domain.Repository, traqRepo *traq.TraQRepository, txManager domain.TransactionManager) domain.Service {
+	return &service{GormRepo: repo, TraQRepo: traqRepo, TxManager: txManager}
 }

--- a/service/tag_impl.go
+++ b/service/tag_impl.go
@@ -8,16 +8,21 @@ import (
 )
 
 func (s *service) CreateOrGetTag(ctx context.Context, name string) (*domain.Tag, error) {
-	t, err := s.GormRepo.CreateOrGetTag(name)
+	var t *domain.Tag
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		var err error
+		t, err = s.GormRepo.CreateOrGetTag(ctx, name)
+		return err
+	})
 	return t, defaultErrorHandling(err)
 }
 
 func (s *service) GetTag(ctx context.Context, tagID uuid.UUID) (*domain.Tag, error) {
-	t, err := s.GormRepo.GetTag(tagID)
+	t, err := s.GormRepo.GetTag(ctx, tagID)
 	return t, defaultErrorHandling(err)
 }
 
 func (s *service) GetAllTags(ctx context.Context) ([]*domain.Tag, error) {
-	ts, err := s.GormRepo.GetAllTags()
+	ts, err := s.GormRepo.GetAllTags(ctx)
 	return ts, defaultErrorHandling(err)
 }

--- a/service/user_impl.go
+++ b/service/user_impl.go
@@ -40,7 +40,9 @@ func (s *service) SyncUsers(ctx context.Context, reqID uuid.UUID) error {
 		args = append(args, a)
 	}
 
-	err = s.GormRepo.SyncUsers(args)
+	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return s.GormRepo.SyncUsers(ctx, args)
+	})
 	return defaultErrorHandling(err)
 }
 
@@ -73,7 +75,10 @@ func (s *service) LoginUser(ctx context.Context, query, state, codeVerifier stri
 			Subject: traQUser.GetId(),
 		},
 	}
-	_, err = s.GormRepo.SaveUser(user)
+	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
+		_, err = s.GormRepo.SaveUser(ctx, user)
+		return err
+	})
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -82,7 +87,7 @@ func (s *service) LoginUser(ctx context.Context, query, state, codeVerifier stri
 }
 
 func (s *service) GetUser(ctx context.Context, userID uuid.UUID) (*domain.User, error) {
-	userMeta, err := s.GormRepo.GetUser(userID)
+	userMeta, err := s.GormRepo.GetUser(ctx, userID)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -104,7 +109,7 @@ func (s *service) GetUserMe(ctx context.Context, reqID uuid.UUID) (*domain.User,
 }
 
 func (s *service) GetAllUsers(ctx context.Context, includeSuspend, includeBot bool) ([]*domain.User, error) {
-	userMetas, err := s.GormRepo.GetAllUsers(!includeSuspend)
+	userMetas, err := s.GormRepo.GetAllUsers(ctx, !includeSuspend)
 	if err != nil {
 		return nil, defaultErrorHandling(err)
 	}
@@ -135,12 +140,14 @@ func (s *service) GetAllUsers(ctx context.Context, includeSuspend, includeBot bo
 
 func (s *service) ReNewMyiCalSecret(ctx context.Context, reqID uuid.UUID) (secret string, err error) {
 	secret = random.AlphaNumeric(16, true)
-	err = s.GormRepo.UpdateiCalSecret(reqID, secret)
+	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return s.GormRepo.UpdateiCalSecret(ctx, reqID, secret)
+	})
 	return
 }
 
 func (s *service) GetMyiCalSecret(ctx context.Context, reqID uuid.UUID) (string, error) {
-	user, err := s.GormRepo.GetUser(reqID)
+	user, err := s.GormRepo.GetUser(ctx, reqID)
 	if err != nil {
 		return "", defaultErrorHandling(err)
 	}
@@ -148,7 +155,7 @@ func (s *service) GetMyiCalSecret(ctx context.Context, reqID uuid.UUID) (string,
 		return "", domain.ErrForbidden
 	}
 	// TODO: userid に対応する ical secret を返す関数を実装
-	secret, err := s.GormRepo.GetICalSecret(reqID)
+	secret, err := s.GormRepo.GetICalSecret(ctx, reqID)
 	if err != nil {
 		return "", defaultErrorHandling(err)
 	}
@@ -159,7 +166,7 @@ func (s *service) GetMyiCalSecret(ctx context.Context, reqID uuid.UUID) (string,
 }
 
 func (s *service) IsPrivilege(ctx context.Context, reqID uuid.UUID) bool {
-	user, err := s.GormRepo.GetUser(reqID)
+	user, err := s.GormRepo.GetUser(ctx, reqID)
 	if err != nil {
 		return false
 	}
@@ -193,13 +200,15 @@ func (s *service) mergeUser(userMeta *domain.User, userBody *traq.User) (*domain
 }
 
 func (s *service) GrantPrivilege(ctx context.Context, userID uuid.UUID) error {
-	user, err := s.GormRepo.GetUser(userID)
+	user, err := s.GormRepo.GetUser(ctx, userID)
 	if err != nil {
 		return defaultErrorHandling(err)
 	}
 	if user.Privileged {
 		return fmt.Errorf("%w: user has been already privileged", domain.ErrBadRequest)
 	}
-	err = s.GormRepo.GrantPrivilege(userID)
+	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
+		return s.GormRepo.GrantPrivilege(ctx, userID)
+	})
 	return defaultErrorHandling(err)
 }

--- a/service/user_impl.go
+++ b/service/user_impl.go
@@ -76,7 +76,7 @@ func (s *service) LoginUser(ctx context.Context, query, state, codeVerifier stri
 		},
 	}
 	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
-		_, err = s.GormRepo.SaveUser(ctx, user)
+		_, err := s.GormRepo.SaveUser(ctx, user)
 		return err
 	})
 	if err != nil {
@@ -200,14 +200,14 @@ func (s *service) mergeUser(userMeta *domain.User, userBody *traq.User) (*domain
 }
 
 func (s *service) GrantPrivilege(ctx context.Context, userID uuid.UUID) error {
-	user, err := s.GormRepo.GetUser(ctx, userID)
-	if err != nil {
-		return defaultErrorHandling(err)
-	}
-	if user.Privileged {
-		return fmt.Errorf("%w: user has been already privileged", domain.ErrBadRequest)
-	}
-	err = s.TxManager.Do(ctx, func(ctx context.Context) error {
+	err := s.TxManager.Do(ctx, func(ctx context.Context) error {
+		user, err := s.GormRepo.GetUser(ctx, userID)
+		if err != nil {
+			return err
+		}
+		if user.Privileged {
+			return fmt.Errorf("%w: user has been already privileged", domain.ErrBadRequest)
+		}
 		return s.GormRepo.GrantPrivilege(ctx, userID)
 	})
 	return defaultErrorHandling(err)

--- a/utils/cron.go
+++ b/utils/cron.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -25,12 +26,12 @@ func InitPostEventToTraQ(repo domain.Repository, secret, channelID, webhookID, o
 		now := setTimeFromString(time.Now().In(tz.JST), "06:00:00")
 		tomorrow := now.AddDate(0, 0, 1)
 
-		rooms, _ := repo.GetAllRooms(now, tomorrow, uuid.Nil)
+		rooms, _ := repo.GetAllRooms(context.Background(), now, tomorrow, uuid.Nil)
 		expr, err := filters.FilterDuration(now, tomorrow)
 		if err != nil {
 			fmt.Println(err)
 		}
-		events, _ := repo.GetAllEvents(expr)
+		events, _ := repo.GetAllEvents(context.Background(), expr)
 		message := createMessage(now, rooms, events, origin)
 		err = RequestWebhook(message, secret, channelID, webhookID, 1)
 		if err != nil {


### PR DESCRIPTION
Service層で複数回のDB操作を行う際にそれらが1つのトランザクションにまとまるようにしました。

e.g.) CreateEvent で部屋が存在しなかった場合の自動生成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * トランザクション管理機能を導入し、書き込み操作を明示的なトランザクション内で実行可能に

* **リファクタリング**
  * すべてのリポジトリ/サービスAPIをコンテキスト対応に変更し、リクエスト単位のキャンセルや期限管理をサポート
  * サービス層がトランザクション管理を利用するように変更し、一貫性とエラーハンドリングを強化

* **バグ修正**
  * テスト内の不要なデバッグ出力を削除

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/knoQ/pull/642)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->