### PR TITLE
security: サプライチェーンハードニング対応（提案・自動生成）

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -37,7 +37,7 @@ services:
           path: ./
 
   db:
-    image: mariadb:10.6.4
+    image: mariadb:10.6.4@sha256:c014ba1efc5dbd711d0520c7762d57807f35549de3414eb31e942a420c8a2ed2
     container_name: knoq_db
     environment:
       MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION
> [!IMPORTANT]
> **これは自動生成された「対応提案」PR です。**
> CI／サプライチェーンのハードニングを進めやすくするために機械的に変更を加えています。
> **変更内容が正しいか・CI が通るかは必ずメンテナご自身でご確認ください。** 誤検出や、このリポジトリの文脈では不要な変更が含まれている可能性があります。不要なものは部分的に revert／close いただいて構いません。

traPtitech org 全体のセキュリティ監査に基づく提案です。

## 適用した変更

### ✅ Docker ベースイメージを digest 固定（1 箇所）
信頼できる発行元（Docker 公式 / distroless / ghcr.io/traPtitech 等）の可変タグに `@sha256:...` を付与しました。
- `mariadb:10.6.4`（`compose.yml`）

## 確認のお願い
- [x] CI が通ることを確認した

## 参考
- SHA pinning: [pinact](https://github.com/suzuki-shunsuke/pinact) ／ Dependabot（`github-actions`）・Renovate（`helpers:pinGitHubActionDigests`）でも自動更新できます
- [Docker Hardened Images](https://www.docker.com/ja-jp/products/hardened-images/)

---
🤖 この PR は traPtitech org セキュリティ監査の一環として自動生成されました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * データベース用コンテナのイメージ指定を固定化し、同じ環境を再現しやすくしました。
  * 予期しないイメージ更新の影響を受けにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->