### PR TITLE
room新規登録条件の変更

### DIFF
--- a/infra/db/event.go
+++ b/infra/db/event.go
@@ -171,7 +171,7 @@ func updateEvent(db *gorm.DB, eventID uuid.UUID, args domain.UpsertEventArgs) (*
 	}
 
 	// 対応する Room, Group はService層で確認済み
-	err = db.Save(&event).Error
+	err = db.Updates(&event).Error
 	if err != nil {
 		return nil, err
 	}

--- a/infra/db/event.go
+++ b/infra/db/event.go
@@ -171,7 +171,7 @@ func updateEvent(db *gorm.DB, eventID uuid.UUID, args domain.UpsertEventArgs) (*
 	}
 
 	// 対応する Room, Group はService層で確認済み
-	err = db.Updates(&event).Error
+	err = db.Save(&event).Error
 	if err != nil {
 		return nil, err
 	}

--- a/infra/db/model.go
+++ b/infra/db/model.go
@@ -24,7 +24,7 @@ var tables = []interface{}{
 }
 
 type Model struct {
-	CreatedAt time.Time
+	CreatedAt time.Time `gorm:"<-:create"`
 	UpdatedAt time.Time
 	DeletedAt gorm.DeletedAt `gorm:"index"`
 }

--- a/service/event_impl.go
+++ b/service/event_impl.go
@@ -108,7 +108,7 @@ func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 				}
 				p.RoomID = r.ID
 			} else {
-				return ErrRoomUndefined
+				return defaultErrorHandling(ErrRoomUndefined)
 			}
 		}
 		var err error

--- a/service/event_impl.go
+++ b/service/event_impl.go
@@ -93,26 +93,22 @@ func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 
 		// RoomIDの存在を確認 RoomがなくPlaceがあれば新たに作成
 		if params.RoomID == uuid.Nil {
-			if currentEvent.Room.ID != uuid.Nil {
-				p.RoomID = currentEvent.Room.ID
-			} else {
-				if params.Place != "" {
-					roomParams := domain.WriteRoomParams{
-						Place:     params.Place,
-						TimeStart: params.TimeStart,
-						TimeEnd:   params.TimeEnd,
-						Admins:    params.Admins,
-					}
-					// UnVerifiedを仮定
-					var r *domain.Room
-					r, err = s.CreateUnVerifiedRoom(ctx, reqID, roomParams)
-					if err != nil {
-						return err
-					}
-					p.RoomID = r.ID
-				} else {
-					return ErrRoomUndefined
+			if params.Place != "" {
+				roomParams := domain.WriteRoomParams{
+					Place:     params.Place,
+					TimeStart: params.TimeStart,
+					TimeEnd:   params.TimeEnd,
+					Admins:    params.Admins,
 				}
+				// UnVerifiedを仮定
+				var r *domain.Room
+				r, err = s.CreateUnVerifiedRoom(ctx, reqID, roomParams)
+				if err != nil {
+					return err
+				}
+				p.RoomID = r.ID
+			} else {
+				return ErrRoomUndefined
 			}
 		}
 		var err error

--- a/service/event_impl.go
+++ b/service/event_impl.go
@@ -91,9 +91,13 @@ func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 			CreatedBy:        reqID,
 		}
 
-		// RoomIDの存在を確認 RoomがなくPlaceがあれば新たに作成
+		// RoomIDの存在を確認
 		if params.RoomID == uuid.Nil {
-			if params.Place != "" {
+			// 部屋に変更がない場合はIDそのまま
+			if currentEvent.Room.Place == p.Place && currentEvent.Room.TimeStart.Equal(p.TimeStart) && currentEvent.Room.TimeEnd.Equal(p.TimeEnd) {
+				p.RoomID = currentEvent.Room.ID
+			} else if params.Place != "" {
+				// RoomがなくPlaceがあれば新たに作成
 				roomParams := domain.WriteRoomParams{
 					Place:     params.Place,
 					TimeStart: params.TimeStart,

--- a/service/event_impl.go
+++ b/service/event_impl.go
@@ -96,23 +96,25 @@ func (s *service) UpdateEvent(ctx context.Context, reqID uuid.UUID, eventID uuid
 			// 部屋に変更がない場合はIDそのまま
 			if currentEvent.Room.Place == p.Place && currentEvent.Room.TimeStart.Equal(p.TimeStart) && currentEvent.Room.TimeEnd.Equal(p.TimeEnd) {
 				p.RoomID = currentEvent.Room.ID
-			} else if params.Place != "" {
-				// RoomがなくPlaceがあれば新たに作成
-				roomParams := domain.WriteRoomParams{
-					Place:     params.Place,
-					TimeStart: params.TimeStart,
-					TimeEnd:   params.TimeEnd,
-					Admins:    params.Admins,
-				}
-				// UnVerifiedを仮定
-				var r *domain.Room
-				r, err = s.CreateUnVerifiedRoom(ctx, reqID, roomParams)
-				if err != nil {
-					return err
-				}
-				p.RoomID = r.ID
 			} else {
-				return defaultErrorHandling(ErrRoomUndefined)
+				if params.Place != "" {
+					// RoomがなくPlaceがあれば新たに作成
+					roomParams := domain.WriteRoomParams{
+						Place:     params.Place,
+						TimeStart: params.TimeStart,
+						TimeEnd:   params.TimeEnd,
+						Admins:    params.Admins,
+					}
+					// UnVerifiedを仮定
+					var r *domain.Room
+					r, err = s.CreateUnVerifiedRoom(ctx, reqID, roomParams)
+					if err != nil {
+						return err
+					}
+					p.RoomID = r.ID
+				} else {
+					return defaultErrorHandling(ErrRoomUndefined)
+				}
 			}
 		}
 		var err error


### PR DESCRIPTION
fix #655 イベントの場所を変更できない

verified roomに変更する場合→ paramにRoomIDが含まれているのでそのまま
unverified roomに変更する場合→roomを新規作成してidを割り当てる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * イベント更新時、ルームIDが未指定でも、更新前とルーム情報（場所・開始/終了時刻）が同一なら既存ルームIDを引き継ぐように見直しました。
  * ルーム情報が異なる場合は、場所が指定されているときのみ新しいルームを作成して関連付けます。
  * 場所が未指定のまま同一判定ができないときは、「ルーム未定義」として適切にエラーを返すよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->