### PR TITLE
issue #660 の解決のために prealloc を設定ファイルから除外しました。

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,4 +8,3 @@ linters:
     - unused
     - ineffassign
     - gocritic
-    - prealloc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,3 +8,4 @@ linters:
     - unused
     - ineffassign
     - gocritic
+    


### PR DESCRIPTION
.golangci.yml の 11 行目を削除しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定変更**
  * `prealloc` リンターの有効化設定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->