### PR TITLE
Feat/issue644

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -104,7 +104,7 @@ paths:
       summary: 部屋を確認する
       description: 特権が必要。部屋が使用できることを確認する
       responses:
-        '200':
+        '204':
           description: successful operation
         '400':
           description: Bad Request
@@ -115,7 +115,7 @@ paths:
       summary: 部屋を未確認にする
       description: 特権が必要。部屋が使用できることの確認を取り消す。
       responses:
-        '200':
+        '204':
           description: successful operation
         '403':
           description: Forbidden

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1942,7 +1942,7 @@ components:
         $ref: '#/components/schemas/DraftEventStatus'
 
     onlyVerified:
-      name: verified
+      name: onlyVerified
       in: query
       required: false
       description: verified のみ取得するためのフィルタ

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -48,6 +48,7 @@ paths:
         - $ref: '#/components/parameters/dateBegin'
         - $ref: '#/components/parameters/dateEnd'
         - $ref: '#/components/parameters/excludeEventID'
+        - $ref: '#/components/parameters/onlyVerified'
       responses:
         '200':
           $ref: '#/components/responses/RoomArray'
@@ -1939,6 +1940,14 @@ components:
       description: ステータスでフィルタ
       schema:
         $ref: '#/components/schemas/DraftEventStatus'
+
+    onlyVerified:
+      name: verified
+      in: query
+      required: false
+      description: verified のみ取得するためのフィルタ
+      schema:
+        type: boolean
 
 externalDocs:
   description: Find out more about Swagger

--- a/domain/room.go
+++ b/domain/room.go
@@ -167,7 +167,7 @@ type RoomService interface {
 	DeleteRoom(ctx context.Context, reqID uuid.UUID, roomID uuid.UUID) error
 
 	GetRoom(ctx context.Context, roomID uuid.UUID, excludeEventID uuid.UUID) (*Room, error)
-	GetAllRooms(ctx context.Context, start time.Time, end time.Time, excludeEventID uuid.UUID) ([]*Room, error)
+	GetAllRooms(ctx context.Context, start time.Time, end time.Time, excludeEventID uuid.UUID, onlyVerified bool) ([]*Room, error)
 	IsRoomAdmins(ctx context.Context, reqID uuid.UUID, roomID uuid.UUID) bool
 }
 
@@ -194,5 +194,5 @@ type RoomRepository interface {
 
 	GetRoom(ctx context.Context, roomID uuid.UUID, excludeEventID uuid.UUID) (*Room, error)
 
-	GetAllRooms(ctx context.Context, start, end time.Time, excludeEventID uuid.UUID) ([]*Room, error)
+	GetAllRooms(ctx context.Context, start, end time.Time, excludeEventID uuid.UUID, onlyVerified bool) ([]*Room, error)
 }

--- a/infra/db/room.go
+++ b/infra/db/room.go
@@ -59,14 +59,14 @@ func (repo *gormRepository) GetRoom(ctx context.Context, roomID uuid.UUID, exclu
 	return &r, nil
 }
 
-func (repo *gormRepository) GetAllRooms(ctx context.Context, start, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
+func (repo *gormRepository) GetAllRooms(ctx context.Context, start, end time.Time, excludeEventID uuid.UUID, onlyVerified bool) ([]*domain.Room, error) {
 	var rooms []*Room
 	var err error
 	tx := getTx(ctx, repo.db.WithContext(ctx))
 	if excludeEventID == uuid.Nil {
-		rooms, err = getAllRooms(roomFullPreload(tx), start, end)
+		rooms, err = getAllRooms(roomFullPreload(tx), start, end, onlyVerified)
 	} else {
-		rooms, err = getAllRooms(roomExcludeEventPreload(tx, excludeEventID), start, end)
+		rooms, err = getAllRooms(roomExcludeEventPreload(tx, excludeEventID), start, end, onlyVerified)
 	}
 	if err != nil {
 		return nil, defaultErrorHandling(err)
@@ -165,13 +165,16 @@ func getRoom(db *gorm.DB, roomID uuid.UUID) (*Room, error) {
 	return &room, err
 }
 
-func getAllRooms(db *gorm.DB, start, end time.Time) ([]*Room, error) {
+func getAllRooms(db *gorm.DB, start, end time.Time, onlyVerified bool) ([]*Room, error) {
 	rooms := make([]*Room, 0)
 	if !start.IsZero() {
 		db = db.Where("time_start >= ?", start)
 	}
 	if !end.IsZero() {
 		db = db.Where("time_end <= ?", end)
+	}
+	if onlyVerified {
+		db = db.Where("verified = ?", true)
 	}
 	err := db.Debug().Order("time_start").Find(&rooms).Error
 	return rooms, err

--- a/router/presentation/query.go
+++ b/router/presentation/query.go
@@ -8,7 +8,7 @@ import (
 )
 
 // getTimeRange ?dateBegin=2020-03-27T00:00:00Z
-func GetTiemRange(values url.Values) (start time.Time, end time.Time, err error) {
+func GetTimeRange(values url.Values) (start time.Time, end time.Time, err error) {
 	if values.Get("dateBegin") != "" {
 		start, err = time.Parse(time.RFC3339, values.Get("dateBegin"))
 		if err != nil {

--- a/router/rooms.go
+++ b/router/rooms.go
@@ -83,7 +83,8 @@ func (h *Handlers) HandleGetRoom(c echo.Context) error {
 // HandleGetRooms traPで確保した部屋情報を取得
 func (h *Handlers) HandleGetRooms(c echo.Context) error {
 	values := c.QueryParams()
-	start, end, err := presentation.GetTiemRange(values)
+	start, end, err := presentation.GetTimeRange(values)
+	onlyVerified := values.Get("onlyVerified") == "true"
 	if err != nil {
 		return notFound(err)
 	}
@@ -93,7 +94,7 @@ func (h *Handlers) HandleGetRooms(c echo.Context) error {
 	}
 
 	ctx := c.Request().Context()
-	rooms, err := h.Service.GetAllRooms(ctx, start, end, excludeEventID)
+	rooms, err := h.Service.GetAllRooms(ctx, start, end, excludeEventID, onlyVerified)
 	if err != nil {
 		return judgeErrorResponse(err)
 	}

--- a/router/utils.go
+++ b/router/utils.go
@@ -30,7 +30,7 @@ func createUserMap(users []*domain.User) map[uuid.UUID]*domain.User {
 }
 
 func getDurationFilter(values url.Values) (filters.Expr, error) {
-	start, end, err := presentation.GetTiemRange(values)
+	start, end, err := presentation.GetTimeRange(values)
 	if err != nil {
 		return nil, err
 	}

--- a/service/room_impl.go
+++ b/service/room_impl.go
@@ -117,8 +117,8 @@ func (s *service) GetRoom(ctx context.Context, roomID uuid.UUID, excludeEventID 
 	return rs, defaultErrorHandling(err)
 }
 
-func (s *service) GetAllRooms(ctx context.Context, start time.Time, end time.Time, excludeEventID uuid.UUID) ([]*domain.Room, error) {
-	rs, err := s.GormRepo.GetAllRooms(ctx, start, end, excludeEventID)
+func (s *service) GetAllRooms(ctx context.Context, start time.Time, end time.Time, excludeEventID uuid.UUID, onlyVerified bool) ([]*domain.Room, error) {
+	rs, err := s.GormRepo.GetAllRooms(ctx, start, end, excludeEventID, onlyVerified)
 	return rs, defaultErrorHandling(err)
 }
 

--- a/utils/cron.go
+++ b/utils/cron.go
@@ -26,7 +26,7 @@ func InitPostEventToTraQ(repo domain.Repository, secret, channelID, webhookID, o
 		now := setTimeFromString(time.Now().In(tz.JST), "06:00:00")
 		tomorrow := now.AddDate(0, 0, 1)
 
-		rooms, _ := repo.GetAllRooms(context.Background(), now, tomorrow, uuid.Nil)
+		rooms, _ := repo.GetAllRooms(context.Background(), now, tomorrow, uuid.Nil, true)
 		expr, err := filters.FilterDuration(now, tomorrow)
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
GET /rooms の query parameter に onlyVerified が追加されました。
onlyVerified を true にすると db の検索時に verified = true のものだけが返されます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `GET /rooms` に `verified` パラメータを追加し、確認済みの部屋だけを取得できるようになりました。

* **変更**
  * 部屋の確認・確認解除APIの成功時ステータスを `204 No Content` に変更しました。
  * 時間範囲取得に関する公開名の誤りを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->